### PR TITLE
pulling command options for all daemons to factorize feature

### DIFF
--- a/include/standalone/parseOptions.hh
+++ b/include/standalone/parseOptions.hh
@@ -10,7 +10,7 @@
 // ====================================================================================================
 // Function declarations
 
-//boost::program_options::variables_map loadConfig(std::string const & configFileName, boost::program_options::options_description const & fileOptions);
+boost::program_options::variables_map loadConfig(std::string const & configFileName, boost::program_options::options_description const & fileOptions);
 					   
 template <typename T>
 void setOption(boost::program_options::options_description * fileOptions, boost::program_options::options_description * commandLineOptions, std::string paramName, std::string paramDesc, T param);

--- a/include/standalone/parseOptions.hh
+++ b/include/standalone/parseOptions.hh
@@ -10,6 +10,8 @@
 // ====================================================================================================
 // Function declarations
 
+//boost::program_options::variables_map loadConfig(std::string const & configFileName, boost::program_options::options_description const & fileOptions);
+					   
 template <typename T>
 void setOption(boost::program_options::options_description * fileOptions, boost::program_options::options_description * commandLineOptions, std::string paramName, std::string paramDesc, T param);
 

--- a/include/standalone/parseOptions.hh
+++ b/include/standalone/parseOptions.hh
@@ -1,0 +1,172 @@
+#ifndef __PARSE_OPTIONS_HH__
+#define __PARSE_OPTIONS_HH__
+
+#include <boost/program_options.hpp>
+#include <stdio.h>
+#include <string>
+#include <sstream>
+#include <syslog.h> 
+
+// ====================================================================================================
+// Function declarations
+
+template <typename T>
+void setOption(boost::program_options::options_description * fileOptions, boost::program_options::options_description * commandLineOptions, std::string paramName, std::string paramDesc, T param);
+
+template <typename T>
+void paramLog(std::string paramBame, T paramValue, std::string where, bool logToSyslog);
+
+template <typename T>
+void setParamValue(T * param, std::string paramName, boost::program_options::variables_map configFileVM, boost::program_options::variables_map commandLineVM, bool logToSyslog);
+
+// ====================================================================================================
+// Function implementations 
+
+template <typename T>
+// Function to add parameters/options to both fileOptions and commandLineOptions Saves a few lines of code. Not necessary.
+void setOption(boost::program_options::options_description * fileOptions, boost::program_options::options_description * commandLineOptions, std::string paramName, std::string paramDesc, T param) {
+  // It's hacky to pass the parameter to this function solely to use its type. May be a better way
+  (void)param;// suppress "unused variable" error
+
+  (*fileOptions).add_options()
+    (paramName.c_str(),
+     boost::program_options::value<T>(),
+     paramDesc.c_str());
+  (*commandLineOptions).add_options()
+    (paramName.c_str(),
+     boost::program_options::value<T>(),
+     paramDesc.c_str());
+}
+
+template <typename T>
+// Log what the parameter value was set to and where it came from
+void paramLog(std::string paramName, T paramValue, std::string where, bool logToSyslog) {
+  // To print almost any type (int, etc) as strings
+  std::stringstream ss;
+  std::string str;
+  ss << paramValue;
+  ss >> str;
+  
+  // for printing bools
+  std::string bStr("b");
+  if(!bStr.compare(typeid(paramValue).name())) {
+    // T is bool
+    if(logToSyslog) {
+      syslog(LOG_INFO, "%s was set to: %s %s\n", paramName.c_str(), (!str.compare("1")) ? "true" : "false", where.c_str()); 
+    } else {
+      fprintf(stdout, "%s was set to: %s %s\n", paramName.c_str(), (!str.compare("1")) ? "true" : "false", where.c_str()); 
+    }
+    return;
+  }
+  
+  // for printing everything else
+  if(logToSyslog) {
+    syslog(LOG_INFO, "%s was set to: %s %s\n", paramName.c_str(), str.c_str(), where.c_str()); 
+  } else {
+    fprintf(stdout, "%s was set to: %s %s\n", paramName.c_str(), str.c_str(), where.c_str());
+  }
+}
+
+template <typename T>
+// Set the value of a parameter by looking at the command line, config file, and default value
+void setParamValue(T * param, std::string paramName, boost::program_options::variables_map configFileVM, boost::program_options::variables_map commandLineVM, bool logToSyslog) {
+  // The order of precedence is: command line specified, config file specified, default
+  
+  if(commandLineVM.count(paramName)) {
+    // parameter value specified at command line
+    paramLog(paramName, commandLineVM[paramName].as<T>(), "(COMMAND LINE)", logToSyslog);
+    *param = commandLineVM[paramName].as<T>();
+    return;
+  }
+      
+  if(configFileVM.count(paramName)) {
+    // parameter value specified in config file
+    paramLog(paramName, configFileVM[paramName].as<T>(), "(CONFIG FILE)", logToSyslog);
+    *param = configFileVM[paramName].as<T>();
+    return;
+  }
+
+  // Parameter not specified anywhere, keep default
+  paramLog(paramName, *param, "(DEFAULT)", logToSyslog);
+  return;
+
+}
+
+  /*
+
+// ====================================================================================================
+// Read from config files and set up all parameters
+// For further information see https://theboostcpplibraries.com/boost.program_options
+
+boost::program_options::variables_map loadConfig(std::string const & configFileName,
+						 boost::program_options::options_description const & fileOptions) {
+  // This is a container for the information that fileOptions will get from the config file
+  boost::program_options::variables_map vm;  
+
+  // Check if config file exists
+  std::ifstream ifs{configFileName};
+  syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
+
+  if(ifs) {
+    // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
+    boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
+  }
+
+  return vm;
+}
+  */
+// // ====================================================================================================
+/*
+// Function to add parameters/options. Saves a few lines of code. Not necessary.
+template <class T>
+void setOption(boost::program_options::options_description * fileOptions, boost::program_options::options_description * commandLineOptions, std::string paramName, std::string paramDesc, T param) {
+  // It's hacky to pass the parameter to this function solely to use its type. May be a better way
+  (*fileOptions).add_options()
+    (paramName.c_str(),
+     boost::program_options::value<T>(),
+     paramDesc.c_str());
+  (*commandLineOptions).add_options()
+    (paramName.c_str(),
+     boost::program_options::value<T>(),
+     paramDesc.c_str());
+}
+
+template <class T>
+// Log what the parameter value was set to and where it came fro
+void paramLog(std::string paramName, T paramValue, std::string where, bool logToSyslog) {
+  std::stringstream ss;
+  std::string str;
+  ss << paramValue;
+  ss >> str;
+  if(logToSyslog) {
+    syslog(LOG_INFO, "%s was set to: %s %s\n", paramName.c_str(), str.c_str(), where.c_str()); 
+  } else {
+    fprintf(stdout, "%s was set to: %s %s\n", paramName.c_str(), str.c_str(), where.c_str());
+  }
+}
+
+template <class T>
+void setParamValue(T * param, std::string paramName, boost::program_options::variables_map configFileVM, boost::program_options::variables_map commandLineVM, bool logToSyslog) {
+  // The order of precedence is: command line specified, config file specified, default
+  
+  if(commandLineVM.count(paramName)) {
+    // parameter value specified at command line
+    paramLog(paramName, commandLineVM[paramName].as<T>(), "(COMMAND LINE)", logToSyslog);
+    *param = commandLineVM[paramName].as<T>();
+    return;
+  }
+      
+  if(configFileVM.count(paramName)) {
+    // parameter value specified in config file
+    paramLog(paramName, configFileVM[paramName].as<T>(), "(CONFIG FILE)", logToSyslog);
+    *param = configFileVM[paramName].as<T>();
+    return;
+  }
+
+  // Parameter not specified anywhere, keep default
+  paramLog(paramName, *param, "(DEFAULT)", logToSyslog);
+  return;
+
+}
+*/ 
+#endif

--- a/src/standalone/SM_boot.cxx
+++ b/src/standalone/SM_boot.cxx
@@ -17,9 +17,11 @@
 #include <boost/program_options.hpp>
 #include <fstream>
 
-#include <tclap/CmdLine.h> //TCLAP parser
+//#include <tclap/CmdLine.h> //TCLAP parser
 
 #include <syslog.h>  ///for syslog
+
+#include <standalone/parseOptions.hh>
 
 #define SEC_IN_US  1000000
 #define NS_IN_US 1000
@@ -66,92 +68,62 @@ boost::program_options::variables_map loadConfig(std::string const & configFileN
 }
 
 // // ====================================================================================================
-// // Function to set the parameter by parsing the command line. In particular, we ensure that the command line default does not override config options obtained from the config file.
-// void setParam(void * param, std::string paramString, boost::program_options::variables_map vm, bool param_from_config) {
-//   
-//   // Set parameter but make sure that the command line default does not override config options obtained from the config file. Every parameter must go through this nested if statement sequence.
-//   
-//   // Set parameter
-//   if(vm.count(paramString)) {
-//     // The parameter exists, but was it defaulted?
-//     if(vm[paramString].defaulted()) {
-//       // We have a defaulted parameter, but do we have a config option obtained from the config file?
-//       if(param_from_config) {
-// 	// We have a config option obtained from the config file. Do nothing
-// 	syslog(LOG_INFO, "Setting %s to (CONFIG FILE)\n", paramString);
-// 	return;
-//       } else {
-// 	// We do not have a config option obtained from the config file. Our default can be used.
-// 	*param = vm[paramString].as<typeof(*param)>();	
-// 	syslog(LOG_INFO, "Setting %s to (DEFAULT)\n", paramString);
-// 	return;
-//       } 
-//     } else { 
-//       // We have a non-defaulted parameter option set from the command line! This trumps everything
-//       *param = vm[paramString].as<typeof(*param)>();      
-//       syslog(LOG_INFO, "Setting %s to (COMMAND LINE)\n", paramString);
-//       return;
-//     }
-//   }
-//   
+// // Function to add parameters/options. Saves a few lines of code. Not necessary.
+// template <class T>
+// void setOption(boost::program_options::options_description * fileOptions, boost::program_options::options_description * commandLineOptions, std::string paramName, std::string paramDesc, T /*param*/) {
+//   //void setOption(boost::program_options::options_description options, std::string paramName, std::string paramDesc, T /*param*/) {
+//   // It's hacky to pass the parameter to this function solely to use its type. May be a better way
+//   (*fileOptions).add_options()
+//     (paramName.c_str(),
+//      boost::program_options::value<T>(),
+//      paramDesc.c_str());
+//   (*commandLineOptions).add_options()
+//     (paramName.c_str(),
+//      boost::program_options::value<T>(),
+//      paramDesc.c_str());
+// //  (*options).add_options()
+// //    (paramName.c_str(),
+// //     boost::program_options::value<T>(),
+// //     paramDesc.c_str());
 // }
-
-// Function to add parameters/options. Saves a few lines of code. Not necessary.
-template <class T>
-void setOption(boost::program_options::options_description * fileOptions, boost::program_options::options_description * commandLineOptions, std::string paramName, std::string paramDesc, T /*param*/) {
-  //void setOption(boost::program_options::options_description options, std::string paramName, std::string paramDesc, T /*param*/) {
-  // It's hacky to pass the parameter to this function solely to use its type. May be a better way
-  (*fileOptions).add_options()
-    (paramName.c_str(),
-     boost::program_options::value<T>(),
-     paramDesc.c_str());
-  (*commandLineOptions).add_options()
-    (paramName.c_str(),
-     boost::program_options::value<T>(),
-     paramDesc.c_str());
-//  (*options).add_options()
-//    (paramName.c_str(),
-//     boost::program_options::value<T>(),
-//     paramDesc.c_str());
-}
-
-template <class T>
-// Log what the parameter value was set to and where it came fro
-void paramLog(std::string paramName, T paramValue, std::string where, bool logToSyslog) {
-  std::stringstream ss;
-  std::string str;
-  ss << paramValue;
-  ss >> str;
-  if(logToSyslog) {
-    syslog(LOG_INFO, "%s was set to: %s %s\n", paramName.c_str(), str.c_str(), where.c_str()); 
-  } else {
-    fprintf(stdout, "%s was set to: %s %s\n", paramName.c_str(), str.c_str(), where.c_str());
-  }
-}
-
-template <class T>
-void setParamValue(T * param, std::string paramName, boost::program_options::variables_map configFileVM, boost::program_options::variables_map commandLineVM, bool logToSyslog) {
-  // The order of precedence is: command line specified, config file specified, default
-  
-  if(commandLineVM.count(paramName)) {
-    // parameter value specified at command line
-    paramLog(paramName, commandLineVM[paramName].as<T>(), "(COMMAND LINE)", logToSyslog);
-    *param = commandLineVM[paramName].as<T>();
-    return;
-  }
-      
-  if(configFileVM.count(paramName)) {
-    // parameter value specified in config file
-    paramLog(paramName, configFileVM[paramName].as<T>(), "(CONFIG FILE)", logToSyslog);
-    *param = configFileVM[paramName].as<T>();
-    return;
-  }
-
-  // Parameter not specified anywhere, keep default
-  paramLog(paramName, *param, "(DEFAULT)", logToSyslog);
-  return;
-
-}
+// 
+// template <class T>
+// // Log what the parameter value was set to and where it came fro
+// void paramLog(std::string paramName, T paramValue, std::string where, bool logToSyslog) {
+//   std::stringstream ss;
+//   std::string str;
+//   ss << paramValue;
+//   ss >> str;
+//   if(logToSyslog) {
+//     syslog(LOG_INFO, "%s was set to: %s %s\n", paramName.c_str(), str.c_str(), where.c_str()); 
+//   } else {
+//     fprintf(stdout, "%s was set to: %s %s\n", paramName.c_str(), str.c_str(), where.c_str());
+//   }
+// }
+// 
+// template <class T>
+// void setParamValue(T * param, std::string paramName, boost::program_options::variables_map configFileVM, boost::program_options::variables_map commandLineVM, bool logToSyslog) {
+//   // The order of precedence is: command line specified, config file specified, default
+//   
+//   if(commandLineVM.count(paramName)) {
+//     // parameter value specified at command line
+//     paramLog(paramName, commandLineVM[paramName].as<T>(), "(COMMAND LINE)", logToSyslog);
+//     *param = commandLineVM[paramName].as<T>();
+//     return;
+//   }
+//       
+//   if(configFileVM.count(paramName)) {
+//     // parameter value specified in config file
+//     paramLog(paramName, configFileVM[paramName].as<T>(), "(CONFIG FILE)", logToSyslog);
+//     *param = configFileVM[paramName].as<T>();
+//     return;
+//   }
+// 
+//   // Parameter not specified anywhere, keep default
+//   paramLog(paramName, *param, "(DEFAULT)", logToSyslog);
+//   return;
+// 
+// }
 // ====================================================================================================
 long us_difftime(struct timespec cur, struct timespec end){ 
   return ( (end.tv_sec  - cur.tv_sec )*SEC_IN_US + 
@@ -275,24 +247,6 @@ void sendTemps(ApolloSM* SM, temperatures temps) {
 
 int main(int argc, char** argv) { 
 
-//  TCLAP::CmdLine cmd("ApolloSM boot interface");
-//  TCLAP::ValueArg<std::string> configFile("c",                 //one char flag
-//					  "config_file",       // full flag name
-//					  "config file",       //description
-//					  false,               //required argument
-//					  DEFAULT_CONFIG_FILE, //Default value
-//					  "string",            //type
-//					  cmd);
-//  TCLAP::ValueArg<std::string>    runPath    ("r","run_path","run path",false,DEFAULT_RUN_DIR ,"string",cmd);
-//  TCLAP::ValueArg<std::string>    pidFileName("p","pid_file","pid file",false,DEFAULT_PID_FILE,"string",cmd);
-//
-//  try {
-//    cmd.parse(argc, argv);
-//  }catch (TCLAP::ArgException &e) {
-//    fprintf(stderr, "Failed to Parse Command Line\n");
-//    return -1;
-//  }
-
   // parameters to get from command line or config file (config file itself will not be in the config file, obviously)
   std::string configFile  = DEFAULT_CONFIG_FILE;
   std::string runPath     = DEFAULT_RUN_DIR;
@@ -409,210 +363,6 @@ int main(int argc, char** argv) {
   setParamValue(&powerupTime        , "cm_powerup_time"   , configFileVM, commandLineVM, true);
   setParamValue(&sensorsThroughZynq , "sensorsThroughZynq", configFileVM, commandLineVM, true);
 
-//  // parameters to get from command line or config file
-//  int polltime_in_seconds = DEFAULT_POLLTIME_IN_SECONDS;
-//  bool powerupCMuC = true;
-//  int powerupTime = DEFAULT_POWERUP_TIME;
-//  bool sensorsThroughZynq = DEFAULT_SENSORS_THROUGH_ZYNQ;
-//  // These "sister" variables, if true, ensure that the command line default does not override the config file 
-////  bool polltime_from_config    = false;
-////  bool powerupCMuC_from_config = false;
-////  bool powerupTime_from_config = false;
-////  bool sTZ_from_config         = false;  
-//
-//  // =========================
-//  // parse command line and config file to set parameters
-//  boost::program_options::options_description fileOptions{"File"}; // for parsing config file
-//  boost::program_options::options_description commandLineOptions{"Options"}; // for parsing command line
-//  setOption(&fileOptions, &commandLineOptions, "polltime"          , "polling interval"             , polltime_in_seconds);
-//  setOption(&fileOptions, &commandLineOptions, "cm_powerup"        , "power up CM uC"               , powerupCMuC);
-//  setOption(&fileOptions, &commandLineOptions, "cm_powerup_time"   , "uC power up wait time"        , powerupTime);
-//  setOption(&fileOptions, &commandLineOptions, "sensorsThroughZynq", "read sensor data through Zynq", sensorsThroughZynq);
-//  boost::program_options::variables_map configFileVM; // for parsing config file
-//  boost::program_options::variables_map commandLineVM; // for parsing command line
-//  syslog(LOG_INFO, "Reading from config file now\n");
-//  try {
-//    // parse config file
-//    configFileVM = loadConfig(configFile, fileOptions);
-//  } catch(const boost::program_options::error &ex) {
-//    syslog(LOG_INFO, "Caught exception in function loadConfig(): %s \n", ex.what());        
-//  }
-//  syslog(LOG_INFO, "Parsing command line now\n");
-//  try {
-//    // parse command line
-//    boost::program_options::store(boost::program_options::parse_command_line(argc, argv, commandLineOptions), commandLineVM);
-//  } catch(const boost::program_options::error &ex) {
-//    syslog(LOG_INFO, "Caught exception while parsing command line: %s \n", ex.what());        
-//  }
-//
-//  // Look at the config file and command line and see if we should change the parameters from their default values
-//  setParamValue(&polltime_in_seconds, "polltime"          , configFileVM, commandLineVM);
-//  setParamValue(&powerupCMuC        , "cm_powerup"        , configFileVM, commandLineVM);
-//  setParamValue(&powerupTime        , "cm_powerup_time"   , configFileVM, commandLineVM);
-//  setParamValue(&sensorsThroughZynq , "sensorsThroughZynq", configFileVM, commandLineVM);
-
-//  // Read from configuration file and set up parameters
-//  syslog(LOG_INFO,"Reading from config file now\n");
-//
-//  // fileOptions is for parsing config files
-//  boost::program_options::options_description fileOptions{"File"};
-//  //sigh... with boost comes compilcated c++ magic
-//  fileOptions.add_options() 
-//    ("polltime", 
-//     boost::program_options::value<int>(),//->default_value(DEFAULT_POLLTIME_IN_SECONDS), 
-//     "polling interval")
-//    ("cm_powerup",
-//     boost::program_options::value<bool>(),//->default_value(true), 
-//     "power up CM uC")
-//    ("cm_powerup_time",
-//     boost::program_options::value<int>(),//->default_value(DEFAULT_POWERUP_TIME), 
-//     "uC powerup wait time")
-//    ("sensorsThroughZynq",
-//     boost::program_options::value<bool>(),//->default_value(DEFAULT_SENSORS_THROUGH_ZYNQ),
-//     "read sensor data through zynq");
-//
-//  boost::program_options::variables_map configOptions;  
-//  try{
-//    configOptions = loadConfig(configFile.getValue(),fileOptions);
-//    // Check for information in configOptions. If they exist set the corresponding "from_config" variable to true so that the command line default doesn't override what we have
-//    if(configOptions.count("polltime")) {
-//      polltime_in_seconds = configOptions["polltime"].as<int>();
-//      polltime_from_config = true;
-//    }  
-//    if(configOptions.count("cm_powerup")) {
-//      powerupCMuC = configOptions["cm_powerup"].as<bool>();
-//      powerupCMuc_from_config = true;
-//    }  
-//    if(configOptions.count("cm_powerup_time")) {
-//      powerupTime = configOptions["cm_powerup_time"].as<int>();
-//      powerupTime_from_config = true;
-//    }  
-//    if(configOptions.count("sensorsThroughZynq")) {
-//      sensorsThroughZynq = configOptions["sensorsThroughZynq"].as<bool>();
-//      sTZ_from_config = true;
-//    }
-//
-//  }catch(const boost::program_options::error &ex){
-//    syslog(LOG_INFO, "Caught exception in function loadConfig(): %s \n", ex.what());    
-//  }
-//  
-//  // ============================================================================
-//  // Parsing command line. Parameters set from the command line will override any parameters set from the config file above.
-//  
-//  syslog(LOG_INFO, "Reading from command line now\n");
-//
-//  // commandLineOptions is for parsing the command line
-//  boost::program_options::options_descriptions commandLineOptions{"Options"};
-//  //sigh... with boost comes compilcated c++ magic
-//  commandLineOptions.add_options() 
-//    ("polltime", 
-//     boost::program_options::value<int>()->default_value(DEFAULT_POLLTIME_IN_SECONDS), 
-//     "polling interval")
-//    ("cm_powerup",
-//     boost::program_options::value<bool>()->default_value(true), 
-//     "power up CM uC")
-//    ("cm_powerup_time",
-//     boost::program_options::value<int>()->default_value(DEFAULT_POWERUP_TIME), 
-//     "uC powerup wait time")
-//    ("sensorsThroughZynq",
-//     boost::program_options::value<bool>()->default_value(DEFAULT_SENSORS_THROUGH_ZYNQ),
-//     "read sensor data through zynq");
-//
-//  boost::program_options::variables_map commandLineVM;  
-//  try{
-//
-//    boost::program_options::store(boost::program_options::parse_command_line(argc, argv, commandLineOptions), commandLineVM);
-// 
-//    //    setParam(param, map, from_config);    
-////    setParam(&polltime_in_seconds, "polltime_in_seconds", commandLineVM, polltime_from_config);
-////    setParam(&powerupCMuC,       , "powerupCMuC",         commandLineVM, powerupCMuC_from_config);
-////    setParam(&powerupTime,       , "powerupTime",         commandLineVM, powerupTime_from_config);
-////    setParam(&sensorsThroughZynq , "sensorsThroughZynq",  commandLineVM, sTZ_from_config);
-//
-//    // Set polltime
-//    if(commandLineVM.count("polltime")) {
-//      // polltime exists, but was it defaulted?
-//      if(commandLineVM["polltime"].defaulted()) {
-//	// We have a defaulted polltime, but do we have a config option obtained from the config file?
-//	if(polltime_from_config) {
-//	  // We have a config option obtained from the config file. Do nothing
-//	  syslog(LOG_INFO, "Setting polltime to %d (CONFIG FILE)\n", polltime_in_seconds);
-//	} else {
-//	  // We do not have a config option obtained from the config file. Our default can be used.
-//	  polltime_in_seconds = commandLineVM["polltime"].as<int>();
-//	  syslog(LOG_INFO, "Setting polltime to %d (DEFAULT)\n", polltime_in_seconds);
-//	} 
-//      } else { 
-//	// We have a non-defaulted parameter option set from the command line! This trumps everything
-//	polltime_in_seconds = commandLineVM["polltime"].as<int>();
-//	syslog(LOG_INFO, "Setting polltime to %d (COMMAND LINE)\n", polltime_in_seconds);
-//      }
-//    }
-//
-//    // Set cm_powerup
-//    if(commandLineVM.count("cm_powerup")) {
-//      // cm_powerup exists, but was it defaulted?
-//      if(commandLineVM["cm_powerup"].defaulted()) {
-//	// We have a defaulted cm_powerup, but do we have a config option obtained from the config file?
-//	if(powerupCMuC_from_config) {
-//	  // We have a config option obtained from the config file. Do nothing
-//	  syslog(LOG_INFO, "Setting cm_powerup to %s (CONFIG FILE)\n", powerupCMuC ? "true" : "false");
-//	} else {
-//	  // We do not have a config option obtained from the config file. Our default can be used.
-//	  powerupCMuC = commandLineVM["cm_powerup"].as<bool>();
-//	  syslog(LOG_INFO, "Setting cm_powerup to %s (DEFAULT)\n", powerupCMuC ? "true" : "false");
-//	} 
-//      } else { 
-//	// We have a non-defaulted parameter option set from the command line! This trumps everything
-//	powerupCMuC = commandLineVM["cm_powerup"].as<bool>();
-//	syslog(LOG_INFO, "Setting cm_powerup to %s (COMMAND LINE)\n", powerupCMuC ? "true" : "false");
-//      }
-//    }
-//
-//    // Set cm_powerup_time
-//    if(commandLineVM.count("cm_powerup_time")) {
-//      // cm_powerup_time exists, but was it defaulted?
-//      if(commandLineVM["cm_powerup_time"].defaulted()) {
-//	// We have a defaulted cm_powerup_time, but do we have a config option obtained from the config file?
-//	if(powerupTime_from_config) {
-//	  // We have a config option obtained from the config file. Do nothing
-//	  syslog(LOG_INFO, "Setting cm_powerup_time to %d (CONFIG FILE)\n", powerupTime);
-//	} else {
-//	  // We do not have a config option obtained from the config file. Our default can be used.
-//	  powerupTime = commandLineVM["cm_powerup_time"].as<int>();
-//	  syslog(LOG_INFO, "Setting cm_powerup_time to %d (DEFAULT)\n", powerupTime);
-//	} 
-//      } else { 
-//	// We have a non-defaulted parameter option set from the command line! This trumps everything
-//	powerupTime = commandLineVM["cm_powerup_time"].as<int>();
-//	syslog(LOG_INFO, "Setting cm_powerup_time to %d (COMMAND LINE)\n", powerupTime);
-//      }
-//    }
-//
-//    // Set sensorsThroughZynq
-//    if(commandLineVM.count("sensorsThroughZynq")) {
-//      // sensorsThroughZynq exists, but was it defaulted?
-//      if(commandLineVM["sensorsThroughZynq"].defaulted()) {
-//	// We have a defaulted sensorsThroughZynq, but do we have a config option obtained from the config file?
-//	if(sTZ_from_config) {
-//	  // We have a config option obtained from the config file. Do nothing
-//	  syslog(LOG_INFO, "Setting sensorsThroughZynq to %s (CONFIG FILE)\n", sensorsThroughZynq ? "true" : "false");
-//	} else {
-//	  // We do not have a config option obtained from the config file. Our default can be used.
-//	  sensorsThroughZynq = commandLineVM["sensorsThroughZynq"].as<bool>();
-//	  syslog(LOG_INFO, "Setting sensorsThroughZynq to %s (DEFAULT)\n", sensorsThroughZynq ? "true" : "false");
-//	} 
-//      } else { 
-//	// We have a non-defaulted parameter option set from the command line! This trumps everything
-//	sensorsThroughZynq = commandLineVM["sensorsThroughZynq"].as<bool>();
-//	syslog(LOG_INFO, "Setting sensorsThroughZynq to %s (COMMAND LINE)\n", sensorsThroughZynq ? "true" : "false");
-//      }
-//    }
-//
-//  }catch(const boost::program_options::error &ex){
-//    syslog(LOG_INFO, "Caught exception while parsing command line: %s \n", ex.what());    
-//  }
-//
   // ============================================================================
   // Daemon code setup
 

--- a/src/standalone/SM_boot.cxx
+++ b/src/standalone/SM_boot.cxx
@@ -21,7 +21,7 @@
 
 #include <syslog.h>  ///for syslog
 
-#include <standalone/parseOptions.hh>
+#include <standalone/parseOptions.hh> // setOptions // setParamValues
 
 #define SEC_IN_US  1000000
 #define NS_IN_US 1000

--- a/src/standalone/SM_boot.cxx
+++ b/src/standalone/SM_boot.cxx
@@ -278,7 +278,7 @@ int main(int argc, char** argv) {
     // parse command line
     boost::program_options::store(boost::program_options::parse_command_line(argc, argv, commandLineOptions), commandLineVM);
   } catch(const boost::program_options::error &ex) {
-    fprintf(stderr, "Caught exception while parsing command line: %s \nTerminating SM_boot\n", ex.what());       
+    fprintf(stderr, "Caught exception while parsing command line: %s. Try (--). ex: --polltime \nTerminating SM_boot\n", ex.what());       
     return -1;
   }
 
@@ -298,7 +298,7 @@ int main(int argc, char** argv) {
     return -1;
   }
 
-  // Look at the config file and command line and see if we should change the parameters from their default values
+  // Look at the config file and command line and determine if we should change the parameters from their default values
   // Only run path and pid file are needed for the next bit of code. The other parameters can and should wait until syslog is available.
   setParamValue(&runPath            , "run_path"          , configFileVM, commandLineVM, false);
   setParamValue(&pidFileName        , "pid_file"          , configFileVM, commandLineVM, false);
@@ -355,9 +355,7 @@ int main(int argc, char** argv) {
   close(STDERR_FILENO);
 
   // ============================================================================
-  // Now that syslog is available, we can continue to look at the config file and command line and see if we should change the parameters from their default values.
-//  setParamValue(&runPath            , "run_path"          , configFileVM, commandLineVM, false);
-//  setParamValue(&pidFileName        , "pid_file"          , configFileVM, commandLineVM, false);
+  // Now that syslog is available, we can continue to look at the config file and command line and determine if we should change the parameters from their default values.
   setParamValue(&polltime_in_seconds, "polltime"          , configFileVM, commandLineVM, true);
   setParamValue(&powerupCMuC        , "cm_powerup"        , configFileVM, commandLineVM, true);
   setParamValue(&powerupTime        , "cm_powerup_time"   , configFileVM, commandLineVM, true);

--- a/src/standalone/SM_boot.cxx
+++ b/src/standalone/SM_boot.cxx
@@ -50,22 +50,22 @@ void static signal_handler(int const signum) {
 // Read from config files and set up all parameters
 // For further information see https://theboostcpplibraries.com/boost.program_options
 
-boost::program_options::variables_map loadConfig(std::string const & configFileName,
-						 boost::program_options::options_description const & fileOptions) {
-  // This is a container for the information that fileOptions will get from the config file
-  boost::program_options::variables_map vm;  
-
-  // Check if config file exists
-  std::ifstream ifs{configFileName};
-  syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
-
-  if(ifs) {
-    // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
-    boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
-  }
-
-  return vm;
-}
+//boost::program_options::variables_map loadConfig(std::string const & configFileName,
+ //						 boost::program_options::options_description const & fileOptions) {
+ // // This is a container for the information that fileOptions will get from the config file
+ // boost::program_options::variables_map vm;  
+ //
+ // // Check if config file exists
+ // std::ifstream ifs{configFileName};
+ // syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
+ //
+ // if(ifs) {
+ //   // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
+ //   boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
+ // }
+ //
+ // return vm;
+ //}
 
 // // ====================================================================================================
 // // Function to add parameters/options. Saves a few lines of code. Not necessary.

--- a/src/standalone/SM_boot.cxx
+++ b/src/standalone/SM_boot.cxx
@@ -17,11 +17,9 @@
 #include <boost/program_options.hpp>
 #include <fstream>
 
-//#include <tclap/CmdLine.h> //TCLAP parser
-
 #include <syslog.h>  ///for syslog
 
-#include <standalone/parseOptions.hh> // setOptions // setParamValues
+#include <standalone/parseOptions.hh> // setOptions // setParamValues // loadConfig
 
 #define SEC_IN_US  1000000
 #define NS_IN_US 1000
@@ -44,92 +42,11 @@ void static signal_handler(int const signum) {
   }
 }
 
-
-
-// ====================================================================================================
-// Read from config files and set up all parameters
-// For further information see https://theboostcpplibraries.com/boost.program_options
-
-//boost::program_options::variables_map loadConfig(std::string const & configFileName,
- //						 boost::program_options::options_description const & fileOptions) {
- // // This is a container for the information that fileOptions will get from the config file
- // boost::program_options::variables_map vm;  
- //
- // // Check if config file exists
- // std::ifstream ifs{configFileName};
- // syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
- //
- // if(ifs) {
- //   // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
- //   boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
- // }
- //
- // return vm;
- //}
-
-// // ====================================================================================================
-// // Function to add parameters/options. Saves a few lines of code. Not necessary.
-// template <class T>
-// void setOption(boost::program_options::options_description * fileOptions, boost::program_options::options_description * commandLineOptions, std::string paramName, std::string paramDesc, T /*param*/) {
-//   //void setOption(boost::program_options::options_description options, std::string paramName, std::string paramDesc, T /*param*/) {
-//   // It's hacky to pass the parameter to this function solely to use its type. May be a better way
-//   (*fileOptions).add_options()
-//     (paramName.c_str(),
-//      boost::program_options::value<T>(),
-//      paramDesc.c_str());
-//   (*commandLineOptions).add_options()
-//     (paramName.c_str(),
-//      boost::program_options::value<T>(),
-//      paramDesc.c_str());
-// //  (*options).add_options()
-// //    (paramName.c_str(),
-// //     boost::program_options::value<T>(),
-// //     paramDesc.c_str());
-// }
-// 
-// template <class T>
-// // Log what the parameter value was set to and where it came fro
-// void paramLog(std::string paramName, T paramValue, std::string where, bool logToSyslog) {
-//   std::stringstream ss;
-//   std::string str;
-//   ss << paramValue;
-//   ss >> str;
-//   if(logToSyslog) {
-//     syslog(LOG_INFO, "%s was set to: %s %s\n", paramName.c_str(), str.c_str(), where.c_str()); 
-//   } else {
-//     fprintf(stdout, "%s was set to: %s %s\n", paramName.c_str(), str.c_str(), where.c_str());
-//   }
-// }
-// 
-// template <class T>
-// void setParamValue(T * param, std::string paramName, boost::program_options::variables_map configFileVM, boost::program_options::variables_map commandLineVM, bool logToSyslog) {
-//   // The order of precedence is: command line specified, config file specified, default
-//   
-//   if(commandLineVM.count(paramName)) {
-//     // parameter value specified at command line
-//     paramLog(paramName, commandLineVM[paramName].as<T>(), "(COMMAND LINE)", logToSyslog);
-//     *param = commandLineVM[paramName].as<T>();
-//     return;
-//   }
-//       
-//   if(configFileVM.count(paramName)) {
-//     // parameter value specified in config file
-//     paramLog(paramName, configFileVM[paramName].as<T>(), "(CONFIG FILE)", logToSyslog);
-//     *param = configFileVM[paramName].as<T>();
-//     return;
-//   }
-// 
-//   // Parameter not specified anywhere, keep default
-//   paramLog(paramName, *param, "(DEFAULT)", logToSyslog);
-//   return;
-// 
-// }
 // ====================================================================================================
 long us_difftime(struct timespec cur, struct timespec end){ 
   return ( (end.tv_sec  - cur.tv_sec )*SEC_IN_US + 
 	   (end.tv_nsec - cur.tv_nsec)/NS_IN_US);
 }
-
 
 // ====================================================================================================
 // Definitions

--- a/src/standalone/heartbeat.cxx
+++ b/src/standalone/heartbeat.cxx
@@ -20,6 +20,8 @@
 
 #include <syslog.h>  ///for syslog
 
+#include <standalone/parseOptions.hh>
+
 #define SEC_IN_US  1000000
 #define NS_IN_US 1000
 
@@ -76,25 +78,74 @@ long us_difftime(struct timespec cur, struct timespec end){
 // ====================================================================================================
 int main(int argc, char** argv) { 
 
-  TCLAP::CmdLine cmd("ApolloSM PS Heartbeat");
-  TCLAP::ValueArg<std::string> configFile("c",                 //one char flag
-					  "config_file",       // full flag name
-					  "config file",       //description
-					  false,               //required argument
-					  DEFAULT_CONFIG_FILE, //Default value
-					  "string",            //type
-					  cmd);
-  TCLAP::ValueArg<std::string>    runPath    ("r","run_path","run path",false,DEFAULT_RUN_DIR ,"string",cmd);
-  TCLAP::ValueArg<std::string>    pidFileName("p","pid_file","pid file",false,DEFAULT_PID_FILE,"string",cmd);
+//  TCLAP::CmdLine cmd("ApolloSM PS Heartbeat");
+//  TCLAP::ValueArg<std::string> configFile("c",                 //one char flag
+//					  "config_file",       // full flag name
+//					  "config file",       //description
+//					  false,               //required argument
+//					  DEFAULT_CONFIG_FILE, //Default value
+//					  "string",            //type
+//					  cmd);
+//  TCLAP::ValueArg<std::string>    runPath    ("r","run_path","run path",false,DEFAULT_RUN_DIR ,"string",cmd);
+//  TCLAP::ValueArg<std::string>    pidFileName("p","pid_file","pid file",false,DEFAULT_PID_FILE,"string",cmd);
+//
+//  try {
+//    cmd.parse(argc, argv);
+//  }catch (TCLAP::ArgException &e) {
+//    fprintf(stderr, "Failed to Parse Command Line\n");
+//    return -1;
+//  }
+//
+  std::string configFile  = DEFAULT_CONFIG_FILE;
+  std::string runPath     = DEFAULT_RUN_DIR;
+  std::string pidFileName = DEFAULT_PID_FILE;
+  int polltime_in_seconds = DEFAULT_POLLTIME_IN_SECONDS;
 
+  // parse command line and config file to set parameters
+  boost::program_options::options_description fileOptions{"File"}; // for parsing config file
+  boost::program_options::options_description commandLineOptions{"Options"}; // for parsing command line
+  commandLineOptions.add_options()
+    ("config_file",
+     boost::program_options::value<std::string>(),
+     "config_file"); // This is the only option not also in the file option (obviously)
+  setOption(&fileOptions, &commandLineOptions, "run_path", "run path"         , runPath);
+  setOption(&fileOptions, &commandLineOptions, "pid_file", "pid file"         , pidFileName);
+  setOption(&fileOptions, &commandLineOptions, "polltime", "polling interval" , polltime_in_seconds);
+  boost::program_options::variables_map configFileVM; // for parsing config file
+  boost::program_options::variables_map commandLineVM; // for parsing command line
+
+  // The command line must be parsed before the config file so that we know if there is a command line specified config file
+  fprintf(stdout, "Parsing command line now\n");
   try {
-    cmd.parse(argc, argv);
-  }catch (TCLAP::ArgException &e) {
-    fprintf(stderr, "Failed to Parse Command Line\n");
+    // parse command line
+    boost::program_options::store(boost::program_options::parse_command_line(argc, argv, commandLineOptions), commandLineVM);
+  } catch(const boost::program_options::error &ex) {
+    fprintf(stderr, "Caught exception while parsing command line: %s. Try (--). ex: --polltime \nTerminating SM_boot\n", ex.what());       
     return -1;
   }
 
+  // Check for non default config file
+  if(commandLineVM.count("config_file")) {
+    configFile = commandLineVM["config_file"].as<std::string>();
+  }  
+  fprintf(stdout, "config file path: %s\n", configFile.c_str());
 
+  // Now the config file may be loaded
+  fprintf(stdout, "Reading from config file now\n");
+  try {
+    // parse config file
+    configFileVM = loadConfig(configFile, fileOptions);
+  } catch(const boost::program_options::error &ex) {
+    fprintf(stdout, "Caught exception in function loadConfig(): %s \nTerminating SM_boot\n", ex.what());        
+    return -1;
+  }
+ 
+
+  // Look at the config file and command line and determine if we should change the parameters from their default values
+  // Only run path and pid file are needed for the next bit of code. The other parameters can and should wait until syslog is available.
+  setParamValue(&runPath    , "run_path", configFileVM, commandLineVM, false);
+  setParamValue(&pidFileName, "pid_file", configFileVM, commandLineVM, false);
+//  setParamValue(&polltime_in_seconds, "polltime"   , configFileVM, commandLineVM, true);
 
   // ============================================================================
   // Deamon book-keeping
@@ -106,7 +157,7 @@ int main(int argc, char** argv) {
     exit(EXIT_FAILURE);
   }else if(pid > 0){
     //We are the parent and created a child with pid pid
-    FILE * pidFile = fopen(pidFileName.getValue().c_str(),"w");
+    FILE * pidFile = fopen(pidFileName.c_str(),"w");
     fprintf(pidFile,"%d\n",pid);
     fclose(pidFile);
     exit(EXIT_SUCCESS);
@@ -132,11 +183,11 @@ int main(int argc, char** argv) {
   syslog(LOG_INFO,"Set SID to %d\n",sid);
 
   //Move to RUN_DIR
-  if ((chdir(runPath.getValue().c_str())) < 0) {
-    syslog(LOG_ERR,"Failed to change path to \"%s\"\n",runPath.getValue().c_str());    
+  if ((chdir(runPath.c_str())) < 0) {
+    syslog(LOG_ERR,"Failed to change path to \"%s\"\n",runPath.c_str());    
     exit(EXIT_FAILURE);
   }
-  syslog(LOG_INFO,"Changed path to \"%s\"\n", runPath.getValue().c_str());    
+  syslog(LOG_INFO,"Changed path to \"%s\"\n", runPath.c_str());    
 
   //Everything looks good, close the standard file fds.
   close(STDIN_FILENO);
@@ -145,32 +196,35 @@ int main(int argc, char** argv) {
 
   
   // ============================================================================
-  // Read from configuration file and set up parameters
-  syslog(LOG_INFO,"Reading from config file now\n");
-  int polltime_in_seconds = DEFAULT_POLLTIME_IN_SECONDS;
- 
-  // fileOptions is for parsing config files
-  boost::program_options::options_description fileOptions{"File"};
-  //sigh... with boost comes compilcated c++ magic
-  fileOptions.add_options() 
-    ("polltime", 
-     boost::program_options::value<int>()->default_value(DEFAULT_POLLTIME_IN_SECONDS), 
-     "polling interval");
-  boost::program_options::variables_map configOptions;  
-  try{
-    configOptions = loadConfig(configFile.getValue(),fileOptions);
-    // Check for information in configOptions
-    if(configOptions.count("polltime")) {
-      polltime_in_seconds = configOptions["polltime"].as<int>();
-    }  
-    syslog(LOG_INFO,
-	   "Setting poll time to %d seconds (%s)\n",
-	   polltime_in_seconds, 
-	   configOptions.count("polltime") ? "CONFIG FILE" : "DEFAULT");
-        
-  }catch(const boost::program_options::error &ex){
-    syslog(LOG_INFO, "Caught exception in function loadConfig(): %s \n", ex.what());    
-  }
+  // Now that syslog is available, we can continue to look at the config file and command line and determine if we should change the parameters from their default values.
+  setParamValue(&polltime_in_seconds, "polltime", configFileVM, commandLineVM, true);
+
+//  // Read from configuration file and set up parameters
+//  syslog(LOG_INFO,"Reading from config file now\n");
+//  int polltime_in_seconds = DEFAULT_POLLTIME_IN_SECONDS;
+// 
+//  // fileOptions is for parsing config files
+//  boost::program_options::options_description fileOptions{"File"};
+//  //sigh... with boost comes compilcated c++ magic
+//  fileOptions.add_options() 
+//    ("polltime", 
+//     boost::program_options::value<int>()->default_value(DEFAULT_POLLTIME_IN_SECONDS), 
+//     "polling interval");
+//  boost::program_options::variables_map configOptions;  
+//  try{
+//    configOptions = loadConfig(configFile.getValue(),fileOptions);
+//    // Check for information in configOptions
+//    if(configOptions.count("polltime")) {
+//      polltime_in_seconds = configOptions["polltime"].as<int>();
+//    }  
+//    syslog(LOG_INFO,
+//	   "Setting poll time to %d seconds (%s)\n",
+//	   polltime_in_seconds, 
+//	   configOptions.count("polltime") ? "CONFIG FILE" : "DEFAULT");
+//        
+//  }catch(const boost::program_options::error &ex){
+//    syslog(LOG_INFO, "Caught exception in function loadConfig(): %s \n", ex.what());    
+//  }
 
 
   // ============================================================================

--- a/src/standalone/heartbeat.cxx
+++ b/src/standalone/heartbeat.cxx
@@ -16,11 +16,11 @@
 #include <boost/program_options.hpp>  //for configfile parsing
 #include <fstream>
 
-#include <tclap/CmdLine.h> //TCLAP parser
+//#include <tclap/CmdLine.h> //TCLAP parser
 
 #include <syslog.h>  ///for syslog
 
-#include <standalone/parseOptions.hh>
+#include <standalone/parseOptions.hh> // setOptions // setParamValues
 
 #define SEC_IN_US  1000000
 #define NS_IN_US 1000
@@ -120,7 +120,7 @@ int main(int argc, char** argv) {
     // parse command line
     boost::program_options::store(boost::program_options::parse_command_line(argc, argv, commandLineOptions), commandLineVM);
   } catch(const boost::program_options::error &ex) {
-    fprintf(stderr, "Caught exception while parsing command line: %s. Try (--). ex: --polltime \nTerminating SM_boot\n", ex.what());       
+    fprintf(stderr, "Caught exception while parsing command line: %s. Try (--). ex: --polltime \nTerminating heartbeat\n", ex.what());       
     return -1;
   }
 
@@ -136,7 +136,7 @@ int main(int argc, char** argv) {
     // parse config file
     configFileVM = loadConfig(configFile, fileOptions);
   } catch(const boost::program_options::error &ex) {
-    fprintf(stdout, "Caught exception in function loadConfig(): %s \nTerminating SM_boot\n", ex.what());        
+    fprintf(stdout, "Caught exception in function loadConfig(): %s \nTerminating heartbeat\n", ex.what());        
     return -1;
   }
  

--- a/src/standalone/heartbeat.cxx
+++ b/src/standalone/heartbeat.cxx
@@ -16,11 +16,9 @@
 #include <boost/program_options.hpp>  //for configfile parsing
 #include <fstream>
 
-//#include <tclap/CmdLine.h> //TCLAP parser
-
 #include <syslog.h>  ///for syslog
 
-#include <standalone/parseOptions.hh> // setOptions // setParamValues
+#include <standalone/parseOptions.hh> // setOptions // setParamValues // loadConfig
 
 #define SEC_IN_US  1000000
 #define NS_IN_US 1000
@@ -40,62 +38,16 @@ void static signal_handler(int const signum) {
   }
 }
 
-
-
-// ====================================================================================================
-// Read from config files and set up all parameters
-// For further information see https://theboostcpplibraries.com/boost.program_options
-
-//boost::program_options::variables_map loadConfig(std::string const & configFileName,
-//						 boost::program_options::options_description const & fileOptions) {
-//  // This is a container for the information that fileOptions will get from the config file
-//  boost::program_options::variables_map vm;  
-//
-//  // Check if config file exists
-//  std::ifstream ifs{configFileName};
-//  syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
-//
-//  if(ifs) {
-//    // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
-//    boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
-//  }
-//
-//  return vm;
-//}
-
-
-
-
 // ====================================================================================================
 long us_difftime(struct timespec cur, struct timespec end){ 
   return ( (end.tv_sec  - cur.tv_sec )*SEC_IN_US + 
 	   (end.tv_nsec - cur.tv_nsec)/NS_IN_US);
 }
 
-
-
-
 // ====================================================================================================
 int main(int argc, char** argv) { 
 
-//  TCLAP::CmdLine cmd("ApolloSM PS Heartbeat");
-//  TCLAP::ValueArg<std::string> configFile("c",                 //one char flag
-//					  "config_file",       // full flag name
-//					  "config file",       //description
-//					  false,               //required argument
-//					  DEFAULT_CONFIG_FILE, //Default value
-//					  "string",            //type
-//					  cmd);
-//  TCLAP::ValueArg<std::string>    runPath    ("r","run_path","run path",false,DEFAULT_RUN_DIR ,"string",cmd);
-//  TCLAP::ValueArg<std::string>    pidFileName("p","pid_file","pid file",false,DEFAULT_PID_FILE,"string",cmd);
-//
-//  try {
-//    cmd.parse(argc, argv);
-//  }catch (TCLAP::ArgException &e) {
-//    fprintf(stderr, "Failed to Parse Command Line\n");
-//    return -1;
-//  }
-//
+  // parameters to get from command line or config file (config file itself will not be in the config file, obviously)
   std::string configFile  = DEFAULT_CONFIG_FILE;
   std::string runPath     = DEFAULT_RUN_DIR;
   std::string pidFileName = DEFAULT_PID_FILE;
@@ -140,7 +92,6 @@ int main(int argc, char** argv) {
     return -1;
   }
  
-
   // Look at the config file and command line and determine if we should change the parameters from their default values
   // Only run path and pid file are needed for the next bit of code. The other parameters can and should wait until syslog is available.
   setParamValue(&runPath    , "run_path", configFileVM, commandLineVM, false);
@@ -198,34 +149,6 @@ int main(int argc, char** argv) {
   // ============================================================================
   // Now that syslog is available, we can continue to look at the config file and command line and determine if we should change the parameters from their default values.
   setParamValue(&polltime_in_seconds, "polltime", configFileVM, commandLineVM, true);
-
-//  // Read from configuration file and set up parameters
-//  syslog(LOG_INFO,"Reading from config file now\n");
-//  int polltime_in_seconds = DEFAULT_POLLTIME_IN_SECONDS;
-// 
-//  // fileOptions is for parsing config files
-//  boost::program_options::options_description fileOptions{"File"};
-//  //sigh... with boost comes compilcated c++ magic
-//  fileOptions.add_options() 
-//    ("polltime", 
-//     boost::program_options::value<int>()->default_value(DEFAULT_POLLTIME_IN_SECONDS), 
-//     "polling interval");
-//  boost::program_options::variables_map configOptions;  
-//  try{
-//    configOptions = loadConfig(configFile.getValue(),fileOptions);
-//    // Check for information in configOptions
-//    if(configOptions.count("polltime")) {
-//      polltime_in_seconds = configOptions["polltime"].as<int>();
-//    }  
-//    syslog(LOG_INFO,
-//	   "Setting poll time to %d seconds (%s)\n",
-//	   polltime_in_seconds, 
-//	   configOptions.count("polltime") ? "CONFIG FILE" : "DEFAULT");
-//        
-//  }catch(const boost::program_options::error &ex){
-//    syslog(LOG_INFO, "Caught exception in function loadConfig(): %s \n", ex.what());    
-//  }
-
 
   // ============================================================================
   // Daemon code setup

--- a/src/standalone/heartbeat.cxx
+++ b/src/standalone/heartbeat.cxx
@@ -46,22 +46,22 @@ void static signal_handler(int const signum) {
 // Read from config files and set up all parameters
 // For further information see https://theboostcpplibraries.com/boost.program_options
 
-boost::program_options::variables_map loadConfig(std::string const & configFileName,
-						 boost::program_options::options_description const & fileOptions) {
-  // This is a container for the information that fileOptions will get from the config file
-  boost::program_options::variables_map vm;  
-
-  // Check if config file exists
-  std::ifstream ifs{configFileName};
-  syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
-
-  if(ifs) {
-    // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
-    boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
-  }
-
-  return vm;
-}
+//boost::program_options::variables_map loadConfig(std::string const & configFileName,
+//						 boost::program_options::options_description const & fileOptions) {
+//  // This is a container for the information that fileOptions will get from the config file
+//  boost::program_options::variables_map vm;  
+//
+//  // Check if config file exists
+//  std::ifstream ifs{configFileName};
+//  syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
+//
+//  if(ifs) {
+//    // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
+//    boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
+//  }
+//
+//  return vm;
+//}
 
 
 

--- a/src/standalone/htmlStatus.cxx
+++ b/src/standalone/htmlStatus.cxx
@@ -16,11 +16,9 @@
 #include <boost/program_options.hpp>  //for configfile parsing
 #include <fstream>
 
-//#include <tclap/CmdLine.h> //TCLAP parser
-
 #include <syslog.h>  ///for syslog
 
-#include <standalone/parseOptions.hh> // setOptions // setParamValue
+#include <standalone/parseOptions.hh> // setOptions // setParamValue // loadConfig
 
 #define SEC_IN_US  1000000
 #define NS_IN_US 1000
@@ -43,34 +41,6 @@ void static signal_handler(int const signum) {
   }
 }
 
-
-
-// ====================================================================================================
-// Read from config files and set up all parameters
-// For further information see https://theboostcpplibraries.com/boost.program_options
-
-// boost::program_options::variables_map loadConfig(std::string const & configFileName,
-// 						 boost::program_options::options_description const & fileOptions) {
-//   // This is a container for the information that fileOptions will get from the config file
-//   boost::program_options::variables_map vm;  
-// 
-//   // Check if config file exists
-//   std::ifstream ifs{configFileName};
-//   syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
-// 
-//   
-// 
-//   if(ifs) {
-//     // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
-//     boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
-//   }
-// 
-//   return vm;
-// }
-
-
-
-
 // ====================================================================================================
 long us_difftime(struct timespec cur, struct timespec end){ 
   return ( (end.tv_sec  - cur.tv_sec )*SEC_IN_US + 
@@ -79,27 +49,8 @@ long us_difftime(struct timespec cur, struct timespec end){
 
 
 int main(int argc, char** argv) {
-    
-//  TCLAP::CmdLine cmd("Apollo status display");
-//  TCLAP::ValueArg<std::string> configFile("c",                 //one char flag
-//					  "config_file",       // full flag name
-//					  "config file",       //description
-//					  false,               //required argument
-//					  DEFAULT_CONFIG_FILE, //Default value
-//					  "string",            //type
-//					  cmd);
-//  TCLAP::ValueArg<std::string>    runPath    ("r","run_path","run path",false,DEFAULT_RUN_DIR ,"string",cmd);
-//  TCLAP::ValueArg<std::string>    pidFileName("p","pid_file","pid file",false,DEFAULT_PID_FILE,"string",cmd);
-//  try {  
-//    //Parse the command line arguments
-//    cmd.parse(argc, argv);
-//  }catch (TCLAP::ArgException &e) {
-//    fprintf(stderr, "Failed to Parse Command Line\n");
-//    return -1;
-//  }
-//
-  // parameters to get from command line or config file (config file itself) will not be in the config file, obviously)
 
+  // parameters to get from command line or config file (config file itself will not be in the config file, obviously)
   std::string configFile  = DEFAULT_CONFIG_FILE;
   std::string runPath     = DEFAULT_RUN_DIR;
   std::string pidFileName = DEFAULT_PID_FILE;
@@ -216,72 +167,6 @@ int main(int argc, char** argv) {
   setParamValue(&outfile            , "outfile"    , configFileVM, commandLineVM, true);
   setParamValue(&logLevel           , "log_level"  , configFileVM, commandLineVM, true);
   setParamValue(&outputType         , "output_type", configFileVM, commandLineVM, true);  
-
-//  // Read from configuration file and set up parameters
-//  syslog(LOG_INFO,"Reading from config file now\n");
-//  int polltime_in_seconds = DEFAULT_POLLTIME_IN_SECONDS;
-//  std::string outfile = DEFAULT_OUTFILE;
-//  std::string outputType = DEFAULT_OUTPUT_TYPE;
-//  int logLevel = DEFAULT_LOG_LEVEL;
-// 
-//  // fileOptions is for parsing config files
-//  boost::program_options::options_description fileOptions{"File"};
-//  //sigh... with boost comes compilcated c++ magic
-//  fileOptions.add_options() 
-//    ("polltime", 
-//     boost::program_options::value<int>()->default_value(DEFAULT_POLLTIME_IN_SECONDS), 
-//     "polling interval")
-//    ("outfile", 
-//     boost::program_options::value<std::string>()->default_value(DEFAULT_OUTFILE), 
-//     "html output file")
-//    ("log_level", 
-//     boost::program_options::value<int>()->default_value(DEFAULT_LOG_LEVEL), 
-//     "status display log level")
-//    ("output_type", 
-//     boost::program_options::value<std::string>()->default_value(DEFAULT_OUTPUT_TYPE), 
-//     "html output type");
-//
-//  boost::program_options::variables_map configOptions;  
-//  try{
-//    configOptions = loadConfig(configFile.getValue(),fileOptions);
-//    // Check for information in configOptions
-//    if(configOptions.count("polltime")) {
-//      polltime_in_seconds = configOptions["polltime"].as<int>();
-//    }
-//    syslog(LOG_INFO,
-//	   "Setting poll time to %d seconds (%s)\n",
-//	   polltime_in_seconds, 
-//	   configOptions.count("polltime") ? "CONFIG FILE" : "DEFAULT");
-//
-//    if(configOptions.count("log_level")) {
-//      logLevel = configOptions["log_level"].as<int>();
-//    }
-//    syslog(LOG_INFO,
-//	   "Setting log level to %d (%s)\n",
-//	   logLevel, 
-//	   configOptions.count("log_level") ? "CONFIG FILE" : "DEFAULT");
-//
-//    if(configOptions.count("outfile")) {
-//      outfile = configOptions["outfile"].as<std::string>();
-//    }
-//    syslog(LOG_INFO,
-//	   "Sending output to %s (%s)\n",
-//	   outfile.c_str(), 
-//	   configOptions.count("outfile") ? "CONFIG FILE" : "DEFAULT");
-//
-//    if(configOptions.count("output_type")) {
-//      outputType = configOptions["output_type"].as<std::string>();
-//    }
-//    syslog(LOG_INFO,
-//	   "Sending output type to %s (%s)\n",
-//	   outputType.c_str(), 
-//	   configOptions.count("output_type") ? "CONFIG FILE" : "DEFAULT");
-//        
-//  }catch(const boost::program_options::error &ex){
-//    syslog(LOG_INFO, "Caught exception in function loadConfig(): %s \n", ex.what());    
-//  }
-//
-//
   // ============================================================================
   // Daemon code setup
 

--- a/src/standalone/htmlStatus.cxx
+++ b/src/standalone/htmlStatus.cxx
@@ -49,24 +49,24 @@ void static signal_handler(int const signum) {
 // Read from config files and set up all parameters
 // For further information see https://theboostcpplibraries.com/boost.program_options
 
-boost::program_options::variables_map loadConfig(std::string const & configFileName,
-						 boost::program_options::options_description const & fileOptions) {
-  // This is a container for the information that fileOptions will get from the config file
-  boost::program_options::variables_map vm;  
-
-  // Check if config file exists
-  std::ifstream ifs{configFileName};
-  syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
-
-  
-
-  if(ifs) {
-    // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
-    boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
-  }
-
-  return vm;
-}
+// boost::program_options::variables_map loadConfig(std::string const & configFileName,
+// 						 boost::program_options::options_description const & fileOptions) {
+//   // This is a container for the information that fileOptions will get from the config file
+//   boost::program_options::variables_map vm;  
+// 
+//   // Check if config file exists
+//   std::ifstream ifs{configFileName};
+//   syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
+// 
+//   
+// 
+//   if(ifs) {
+//     // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
+//     boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
+//   }
+// 
+//   return vm;
+// }
 
 
 

--- a/src/standalone/htmlStatus.cxx
+++ b/src/standalone/htmlStatus.cxx
@@ -16,11 +16,11 @@
 #include <boost/program_options.hpp>  //for configfile parsing
 #include <fstream>
 
-#include <tclap/CmdLine.h> //TCLAP parser
+//#include <tclap/CmdLine.h> //TCLAP parser
 
 #include <syslog.h>  ///for syslog
 
-#include <standalone/parseOptions.hh>
+#include <standalone/parseOptions.hh> // setOptions // setParamValue
 
 #define SEC_IN_US  1000000
 #define NS_IN_US 1000
@@ -130,7 +130,7 @@ int main(int argc, char** argv) {
     // parse command line
     boost::program_options::store(boost::program_options::parse_command_line(argc, argv, commandLineOptions), commandLineVM);
   } catch(const boost::program_options::error &ex) {
-    fprintf(stderr, "Caught exception while parsing command line: %s. Try (--). ex: --polltime \nTerminating SM_boot\n", ex.what());       
+    fprintf(stderr, "Caught exception while parsing command line: %s. Try (--). ex: --polltime \nTerminating htmlStatus\n", ex.what());       
     return -1;
   }
 
@@ -146,7 +146,7 @@ int main(int argc, char** argv) {
     // parse config file
     configFileVM = loadConfig(configFile, fileOptions);
   } catch(const boost::program_options::error &ex) {
-    fprintf(stdout, "Caught exception in function loadConfig(): %s \nTerminating SM_boot\n", ex.what());        
+    fprintf(stdout, "Caught exception in function loadConfig(): %s \nTerminating htmlStatus\n", ex.what());        
     return -1;
   }
  

--- a/src/standalone/htmlStatus.cxx
+++ b/src/standalone/htmlStatus.cxx
@@ -20,6 +20,8 @@
 
 #include <syslog.h>  ///for syslog
 
+#include <standalone/parseOptions.hh>
+
 #define SEC_IN_US  1000000
 #define NS_IN_US 1000
 
@@ -78,23 +80,85 @@ long us_difftime(struct timespec cur, struct timespec end){
 
 int main(int argc, char** argv) {
     
-  TCLAP::CmdLine cmd("Apollo status display");
-  TCLAP::ValueArg<std::string> configFile("c",                 //one char flag
-					  "config_file",       // full flag name
-					  "config file",       //description
-					  false,               //required argument
-					  DEFAULT_CONFIG_FILE, //Default value
-					  "string",            //type
-					  cmd);
-  TCLAP::ValueArg<std::string>    runPath    ("r","run_path","run path",false,DEFAULT_RUN_DIR ,"string",cmd);
-  TCLAP::ValueArg<std::string>    pidFileName("p","pid_file","pid file",false,DEFAULT_PID_FILE,"string",cmd);
-  try {  
-    //Parse the command line arguments
-    cmd.parse(argc, argv);
-  }catch (TCLAP::ArgException &e) {
-    fprintf(stderr, "Failed to Parse Command Line\n");
+//  TCLAP::CmdLine cmd("Apollo status display");
+//  TCLAP::ValueArg<std::string> configFile("c",                 //one char flag
+//					  "config_file",       // full flag name
+//					  "config file",       //description
+//					  false,               //required argument
+//					  DEFAULT_CONFIG_FILE, //Default value
+//					  "string",            //type
+//					  cmd);
+//  TCLAP::ValueArg<std::string>    runPath    ("r","run_path","run path",false,DEFAULT_RUN_DIR ,"string",cmd);
+//  TCLAP::ValueArg<std::string>    pidFileName("p","pid_file","pid file",false,DEFAULT_PID_FILE,"string",cmd);
+//  try {  
+//    //Parse the command line arguments
+//    cmd.parse(argc, argv);
+//  }catch (TCLAP::ArgException &e) {
+//    fprintf(stderr, "Failed to Parse Command Line\n");
+//    return -1;
+//  }
+//
+  // parameters to get from command line or config file (config file itself) will not be in the config file, obviously)
+
+  std::string configFile  = DEFAULT_CONFIG_FILE;
+  std::string runPath     = DEFAULT_RUN_DIR;
+  std::string pidFileName = DEFAULT_PID_FILE;
+  int polltime_in_seconds = DEFAULT_POLLTIME_IN_SECONDS;
+  std::string outfile     = DEFAULT_OUTFILE;
+  int logLevel            = DEFAULT_LOG_LEVEL;
+  std::string outputType  = DEFAULT_OUTPUT_TYPE;
+
+  // parse command line and config file to set parameters
+  boost::program_options::options_description fileOptions{"File"}; // for parsing config file
+  boost::program_options::options_description commandLineOptions{"Options"}; // for parsing command line
+  commandLineOptions.add_options()
+    ("config_file",
+     boost::program_options::value<std::string>(),
+     "config_file"); // This is the only option not also in the file option (obviously)
+  setOption(&fileOptions, &commandLineOptions, "run_path"   , "run path"                , runPath);
+  setOption(&fileOptions, &commandLineOptions, "pid_file"   , "pid file"                , pidFileName);
+  setOption(&fileOptions, &commandLineOptions, "polltime"   , "polling interval"        , polltime_in_seconds);
+  setOption(&fileOptions, &commandLineOptions, "outfile"    , "html output file"        , outfile);
+  setOption(&fileOptions, &commandLineOptions, "log_level"  , "status display log level", outputType);
+  setOption(&fileOptions, &commandLineOptions, "output_type", "html output type"        , logLevel);
+  boost::program_options::variables_map configFileVM; // for parsing config file
+  boost::program_options::variables_map commandLineVM; // for parsing command line
+
+  // The command line must be parsed before the config file so that we know if there is a command line specified config file
+  fprintf(stdout, "Parsing command line now\n");
+  try {
+    // parse command line
+    boost::program_options::store(boost::program_options::parse_command_line(argc, argv, commandLineOptions), commandLineVM);
+  } catch(const boost::program_options::error &ex) {
+    fprintf(stderr, "Caught exception while parsing command line: %s. Try (--). ex: --polltime \nTerminating SM_boot\n", ex.what());       
     return -1;
   }
+
+  // Check for non default config file
+  if(commandLineVM.count("config_file")) {
+    configFile = commandLineVM["config_file"].as<std::string>();
+  }  
+  fprintf(stdout, "config file path: %s\n", configFile.c_str());
+
+  // Now the config file may be loaded
+  fprintf(stdout, "Reading from config file now\n");
+  try {
+    // parse config file
+    configFileVM = loadConfig(configFile, fileOptions);
+  } catch(const boost::program_options::error &ex) {
+    fprintf(stdout, "Caught exception in function loadConfig(): %s \nTerminating SM_boot\n", ex.what());        
+    return -1;
+  }
+ 
+
+  // Look at the config file and command line and determine if we should change the parameters from their default values
+  // Only run path and pid file are needed for the next bit of code. The other parameters can and should wait until syslog is available.
+  setParamValue(&runPath            , "run_path"     , configFileVM, commandLineVM, false);
+  setParamValue(&pidFileName        , "pid_file"     , configFileVM, commandLineVM, false);
+//  setParamValue(&polltime_in_seconds, "polltime"   , configFileVM, commandLineVM, true);
+//  setParamValue(&powerupCMuC        , "outfile"    , configFileVM, commandLineVM, true);
+//  setParamValue(&powerupTime        , "log_level"  , configFileVM, commandLineVM, true);
+//  setParamValue(&sensorsThroughZynq , "output_type", configFileVM, commandLineVM, true);  
 
   // ============================================================================
   // Deamon book-keeping
@@ -106,7 +170,7 @@ int main(int argc, char** argv) {
     exit(EXIT_FAILURE);
   }else if(pid > 0){
     //We are the parent and created a child with pid pid
-    FILE * pidFile = fopen(pidFileName.getValue().c_str(),"w");
+    FILE * pidFile = fopen(pidFileName.c_str(),"w");
     fprintf(pidFile,"%d\n",pid);
     fclose(pidFile);
     exit(EXIT_SUCCESS);
@@ -132,11 +196,11 @@ int main(int argc, char** argv) {
   syslog(LOG_INFO,"Set SID to %d\n",sid);
 
   //Move to RUN_DIR
-  if ((chdir(runPath.getValue().c_str())) < 0) {
-    syslog(LOG_ERR,"Failed to change path to \"%s\"\n",runPath.getValue().c_str());    
+  if ((chdir(runPath.c_str())) < 0) {
+    syslog(LOG_ERR,"Failed to change path to \"%s\"\n",runPath.c_str());    
     exit(EXIT_FAILURE);
   }
-  syslog(LOG_INFO,"Changed path to \"%s\"\n", runPath.getValue().c_str());    
+  syslog(LOG_INFO,"Changed path to \"%s\"\n", runPath.c_str());    
 
   //Everything looks good, close the standard file fds.
   close(STDIN_FILENO);
@@ -147,71 +211,77 @@ int main(int argc, char** argv) {
 
 
   // ============================================================================
-  // Read from configuration file and set up parameters
-  syslog(LOG_INFO,"Reading from config file now\n");
-  int polltime_in_seconds = DEFAULT_POLLTIME_IN_SECONDS;
-  std::string outfile = DEFAULT_OUTFILE;
-  std::string outputType = DEFAULT_OUTPUT_TYPE;
-  int logLevel = DEFAULT_LOG_LEVEL;
- 
-  // fileOptions is for parsing config files
-  boost::program_options::options_description fileOptions{"File"};
-  //sigh... with boost comes compilcated c++ magic
-  fileOptions.add_options() 
-    ("polltime", 
-     boost::program_options::value<int>()->default_value(DEFAULT_POLLTIME_IN_SECONDS), 
-     "polling interval")
-    ("outfile", 
-     boost::program_options::value<std::string>()->default_value(DEFAULT_OUTFILE), 
-     "html output file")
-    ("log_level", 
-     boost::program_options::value<int>()->default_value(DEFAULT_LOG_LEVEL), 
-     "status display log level")
-    ("output_type", 
-     boost::program_options::value<std::string>()->default_value(DEFAULT_OUTPUT_TYPE), 
-     "html output type");
+  // Now that syslog is available, we can continue to look at the config file and command line and determine if we should change the parameters from their default values.
+  setParamValue(&polltime_in_seconds, "polltime"   , configFileVM, commandLineVM, true);
+  setParamValue(&outfile            , "outfile"    , configFileVM, commandLineVM, true);
+  setParamValue(&logLevel           , "log_level"  , configFileVM, commandLineVM, true);
+  setParamValue(&outputType         , "output_type", configFileVM, commandLineVM, true);  
 
-  boost::program_options::variables_map configOptions;  
-  try{
-    configOptions = loadConfig(configFile.getValue(),fileOptions);
-    // Check for information in configOptions
-    if(configOptions.count("polltime")) {
-      polltime_in_seconds = configOptions["polltime"].as<int>();
-    }
-    syslog(LOG_INFO,
-	   "Setting poll time to %d seconds (%s)\n",
-	   polltime_in_seconds, 
-	   configOptions.count("polltime") ? "CONFIG FILE" : "DEFAULT");
-
-    if(configOptions.count("log_level")) {
-      logLevel = configOptions["log_level"].as<int>();
-    }
-    syslog(LOG_INFO,
-	   "Setting log level to %d (%s)\n",
-	   logLevel, 
-	   configOptions.count("log_level") ? "CONFIG FILE" : "DEFAULT");
-
-    if(configOptions.count("outfile")) {
-      outfile = configOptions["outfile"].as<std::string>();
-    }
-    syslog(LOG_INFO,
-	   "Sending output to %s (%s)\n",
-	   outfile.c_str(), 
-	   configOptions.count("outfile") ? "CONFIG FILE" : "DEFAULT");
-
-    if(configOptions.count("output_type")) {
-      outputType = configOptions["output_type"].as<std::string>();
-    }
-    syslog(LOG_INFO,
-	   "Sending output type to %s (%s)\n",
-	   outputType.c_str(), 
-	   configOptions.count("output_type") ? "CONFIG FILE" : "DEFAULT");
-        
-  }catch(const boost::program_options::error &ex){
-    syslog(LOG_INFO, "Caught exception in function loadConfig(): %s \n", ex.what());    
-  }
-
-
+//  // Read from configuration file and set up parameters
+//  syslog(LOG_INFO,"Reading from config file now\n");
+//  int polltime_in_seconds = DEFAULT_POLLTIME_IN_SECONDS;
+//  std::string outfile = DEFAULT_OUTFILE;
+//  std::string outputType = DEFAULT_OUTPUT_TYPE;
+//  int logLevel = DEFAULT_LOG_LEVEL;
+// 
+//  // fileOptions is for parsing config files
+//  boost::program_options::options_description fileOptions{"File"};
+//  //sigh... with boost comes compilcated c++ magic
+//  fileOptions.add_options() 
+//    ("polltime", 
+//     boost::program_options::value<int>()->default_value(DEFAULT_POLLTIME_IN_SECONDS), 
+//     "polling interval")
+//    ("outfile", 
+//     boost::program_options::value<std::string>()->default_value(DEFAULT_OUTFILE), 
+//     "html output file")
+//    ("log_level", 
+//     boost::program_options::value<int>()->default_value(DEFAULT_LOG_LEVEL), 
+//     "status display log level")
+//    ("output_type", 
+//     boost::program_options::value<std::string>()->default_value(DEFAULT_OUTPUT_TYPE), 
+//     "html output type");
+//
+//  boost::program_options::variables_map configOptions;  
+//  try{
+//    configOptions = loadConfig(configFile.getValue(),fileOptions);
+//    // Check for information in configOptions
+//    if(configOptions.count("polltime")) {
+//      polltime_in_seconds = configOptions["polltime"].as<int>();
+//    }
+//    syslog(LOG_INFO,
+//	   "Setting poll time to %d seconds (%s)\n",
+//	   polltime_in_seconds, 
+//	   configOptions.count("polltime") ? "CONFIG FILE" : "DEFAULT");
+//
+//    if(configOptions.count("log_level")) {
+//      logLevel = configOptions["log_level"].as<int>();
+//    }
+//    syslog(LOG_INFO,
+//	   "Setting log level to %d (%s)\n",
+//	   logLevel, 
+//	   configOptions.count("log_level") ? "CONFIG FILE" : "DEFAULT");
+//
+//    if(configOptions.count("outfile")) {
+//      outfile = configOptions["outfile"].as<std::string>();
+//    }
+//    syslog(LOG_INFO,
+//	   "Sending output to %s (%s)\n",
+//	   outfile.c_str(), 
+//	   configOptions.count("outfile") ? "CONFIG FILE" : "DEFAULT");
+//
+//    if(configOptions.count("output_type")) {
+//      outputType = configOptions["output_type"].as<std::string>();
+//    }
+//    syslog(LOG_INFO,
+//	   "Sending output type to %s (%s)\n",
+//	   outputType.c_str(), 
+//	   configOptions.count("output_type") ? "CONFIG FILE" : "DEFAULT");
+//        
+//  }catch(const boost::program_options::error &ex){
+//    syslog(LOG_INFO, "Caught exception in function loadConfig(): %s \n", ex.what());    
+//  }
+//
+//
   // ============================================================================
   // Daemon code setup
 

--- a/src/standalone/parseOptions.cc
+++ b/src/standalone/parseOptions.cc
@@ -1,0 +1,22 @@
+#include <standalone/parseOptions.hh>
+#include <boost/program_options.hpp>
+#include <fstream>
+
+// non-template function implementations
+
+boost::program_options::variables_map loadConfig(std::string const & configFileName,
+						 boost::program_options::options_description const & fileOptions) {
+  // This is a container for the information that fileOptions will get from the config file
+  boost::program_options::variables_map vm;  
+
+  // Check if config file exists
+  std::ifstream ifs{configFileName};
+  syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
+
+  if(ifs) {
+    // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
+    boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
+  }
+
+  return vm;
+}

--- a/src/standalone/parseOptions.cc
+++ b/src/standalone/parseOptions.cc
@@ -18,7 +18,5 @@ boost::program_options::variables_map loadConfig(std::string const & configFileN
     boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
   }
 
-  syslog(LOG_INFO, "load worked!!\n");
-
   return vm;
 }

--- a/src/standalone/parseOptions.cc
+++ b/src/standalone/parseOptions.cc
@@ -18,5 +18,7 @@ boost::program_options::variables_map loadConfig(std::string const & configFileN
     boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
   }
 
+  syslog(LOG_INFO, "load worked!!\n");
+
   return vm;
 }

--- a/src/standalone/ps_monitor.cxx
+++ b/src/standalone/ps_monitor.cxx
@@ -27,11 +27,11 @@
 #include <boost/program_options.hpp>  //for configfile parsing
 #include <fstream>
 
-#include <tclap/CmdLine.h> //TCLAP parser
+//#include <tclap/CmdLine.h> //TCLAP parser
 
 #include <syslog.h>  ///for syslog
 
-#include <standalone/parseOptions.hh>
+#include <standalone/parseOptions.hh> // setOptions // setParamValues
 
 #define SEC_IN_US  1000000
 #define NS_IN_US 1000
@@ -131,7 +131,7 @@ int main(int argc, char ** argv) {
     // parse command line
     boost::program_options::store(boost::program_options::parse_command_line(argc, argv, commandLineOptions), commandLineVM);
   } catch(const boost::program_options::error &ex) {
-    fprintf(stderr, "Caught exception while parsing command line: %s. Try (--). ex: --polltime \nTerminating SM_boot\n", ex.what());       
+    fprintf(stderr, "Caught exception while parsing command line: %s. Try (--). ex: --polltime \nTerminating ps_monitor\n", ex.what());       
     return -1;
   }
 
@@ -147,7 +147,7 @@ int main(int argc, char ** argv) {
     // parse config file
     configFileVM = loadConfig(configFile, fileOptions);
   } catch(const boost::program_options::error &ex) {
-    fprintf(stdout, "Caught exception in function loadConfig(): %s \nTerminating SM_boot\n", ex.what());        
+    fprintf(stdout, "Caught exception in function loadConfig(): %s \nTerminating ps_monitor\n", ex.what());        
     return -1;
   }
  

--- a/src/standalone/ps_monitor.cxx
+++ b/src/standalone/ps_monitor.cxx
@@ -57,22 +57,22 @@ void static signal_handler(int const signum) {
 // Read from config files and set up all parameters
 // For further information see https://theboostcpplibraries.com/boost.program_options
 
-boost::program_options::variables_map loadConfig(std::string const & configFileName,
-						 boost::program_options::options_description const & fileOptions) {
-  // This is a container for the information that fileOptions will get from the config file
-  boost::program_options::variables_map vm;  
-
-  // Check if config file exists
-  std::ifstream ifs{configFileName};
-  syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
-
-  if(ifs) {
-    // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
-    boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
-  }
-
-  return vm;
-}
+// boost::program_options::variables_map loadConfig(std::string const & configFileName,
+// 						 boost::program_options::options_description const & fileOptions) {
+//   // This is a container for the information that fileOptions will get from the config file
+//   boost::program_options::variables_map vm;  
+// 
+//   // Check if config file exists
+//   std::ifstream ifs{configFileName};
+//   syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
+// 
+//   if(ifs) {
+//     // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
+//     boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
+//   }
+// 
+//   return vm;
+// }
 
 
 

--- a/src/standalone/ps_monitor.cxx
+++ b/src/standalone/ps_monitor.cxx
@@ -31,6 +31,8 @@
 
 #include <syslog.h>  ///for syslog
 
+#include <standalone/parseOptions.hh>
+
 #define SEC_IN_US  1000000
 #define NS_IN_US 1000
 
@@ -85,23 +87,76 @@ long us_difftime(struct timespec cur, struct timespec end){
 
 int main(int argc, char ** argv) {
 
-  TCLAP::CmdLine cmd("ApolloSM PS Monitor");
-  TCLAP::ValueArg<std::string> configFile("c",                 //one char flag
-					  "config_file",       // full flag name
-					  "config file",       //description
-					  false,               //required argument
-					  DEFAULT_CONFIG_FILE, //Default value
-					  "string",            //type
-					  cmd);
-  TCLAP::ValueArg<std::string>    runPath    ("r","run_path","run path",false,DEFAULT_RUN_DIR ,"string",cmd);
-  TCLAP::ValueArg<std::string>    pidFileName("p","pid_file","pid file",false,DEFAULT_PID_FILE,"string",cmd);
+//  TCLAP::CmdLine cmd("ApolloSM PS Monitor");
+//  TCLAP::ValueArg<std::string> configFile("c",                 //one char flag
+//					  "config_file",       // full flag name
+//					  "config file",       //description
+//					  false,               //required argument
+//					  DEFAULT_CONFIG_FILE, //Default value
+//					  "string",            //type
+//					  cmd);
+//  TCLAP::ValueArg<std::string>    runPath    ("r","run_path","run path",false,DEFAULT_RUN_DIR ,"string",cmd);
+//  TCLAP::ValueArg<std::string>    pidFileName("p","pid_file","pid file",false,DEFAULT_PID_FILE,"string",cmd);
+//
+//  try {
+//    cmd.parse(argc, argv);
+//  }catch (TCLAP::ArgException &e) {
+//    fprintf(stderr, "Failed to Parse Command Line\n");
+//    return -1;
+//  }
 
+  // parameters to get from command line or config file (config file itself) will not be in the config file, obviously)
+
+  std::string configFile  = DEFAULT_CONFIG_FILE;
+  std::string runPath     = DEFAULT_RUN_DIR;
+  std::string pidFileName = DEFAULT_PID_FILE;
+  int polltime_in_seconds = DEFAULT_POLLTIME_IN_SECONDS;
+
+  // parse command line and config file to set parameters
+  boost::program_options::options_description fileOptions{"File"}; // for parsing config file
+  boost::program_options::options_description commandLineOptions{"Options"}; // for parsing command line
+  commandLineOptions.add_options()
+    ("config_file",
+     boost::program_options::value<std::string>(),
+     "config_file"); // This is the only option not also in the file option (obviously)
+  setOption(&fileOptions, &commandLineOptions, "run_path", "run path"         , runPath);
+  setOption(&fileOptions, &commandLineOptions, "pid_file", "pid file"         , pidFileName);
+  setOption(&fileOptions, &commandLineOptions, "polltime", "polling interval" , polltime_in_seconds);
+  boost::program_options::variables_map configFileVM; // for parsing config file
+  boost::program_options::variables_map commandLineVM; // for parsing command line
+
+  // The command line must be parsed before the config file so that we know if there is a command line specified config file
+  fprintf(stdout, "Parsing command line now\n");
   try {
-    cmd.parse(argc, argv);
-  }catch (TCLAP::ArgException &e) {
-    fprintf(stderr, "Failed to Parse Command Line\n");
+    // parse command line
+    boost::program_options::store(boost::program_options::parse_command_line(argc, argv, commandLineOptions), commandLineVM);
+  } catch(const boost::program_options::error &ex) {
+    fprintf(stderr, "Caught exception while parsing command line: %s. Try (--). ex: --polltime \nTerminating SM_boot\n", ex.what());       
     return -1;
   }
+
+  // Check for non default config file
+  if(commandLineVM.count("config_file")) {
+    configFile = commandLineVM["config_file"].as<std::string>();
+  }  
+  fprintf(stdout, "config file path: %s\n", configFile.c_str());
+
+  // Now the config file may be loaded
+  fprintf(stdout, "Reading from config file now\n");
+  try {
+    // parse config file
+    configFileVM = loadConfig(configFile, fileOptions);
+  } catch(const boost::program_options::error &ex) {
+    fprintf(stdout, "Caught exception in function loadConfig(): %s \nTerminating SM_boot\n", ex.what());        
+    return -1;
+  }
+ 
+
+  // Look at the config file and command line and determine if we should change the parameters from their default values
+  // Only run path and pid file are needed for the next bit of code. The other parameters can and should wait until syslog is available.
+  setParamValue(&runPath    , "run_path", configFileVM, commandLineVM, false);
+  setParamValue(&pidFileName, "pid_file", configFileVM, commandLineVM, false);
+//  setParamValue(&polltime_in_seconds, "polltime"   , configFileVM, commandLineVM, true);
 
   // ============================================================================
   // Deamon book-keeping
@@ -113,7 +168,7 @@ int main(int argc, char ** argv) {
     exit(EXIT_FAILURE);
   }else if(pid > 0){
     //We are the parent and created a child with pid pid
-    FILE * pidFile = fopen(pidFileName.getValue().c_str(),"w");
+    FILE * pidFile = fopen(pidFileName.c_str(),"w");
     fprintf(pidFile,"%d\n",pid);
     fclose(pidFile);
     exit(EXIT_SUCCESS);
@@ -139,11 +194,11 @@ int main(int argc, char ** argv) {
   syslog(LOG_INFO,"Set SID to %d\n",sid);
 
   //Move to RUN_DIR
-  if ((chdir(runPath.getValue().c_str())) < 0) {
-    syslog(LOG_ERR,"Failed to change path to \"%s\"\n",runPath.getValue().c_str());    
+  if ((chdir(runPath.c_str())) < 0) {
+    syslog(LOG_ERR,"Failed to change path to \"%s\"\n",runPath.c_str());    
     exit(EXIT_FAILURE);
   }
-  syslog(LOG_INFO,"Changed path to \"%s\"\n", runPath.getValue().c_str());    
+  syslog(LOG_INFO,"Changed path to \"%s\"\n", runPath.c_str());    
 
   //Everything looks good, close the standard file fds.
   close(STDIN_FILENO);
@@ -152,32 +207,36 @@ int main(int argc, char ** argv) {
 
   
   // ============================================================================
-  // Read from configuration file and set up parameters
-  syslog(LOG_INFO,"Reading from config file now\n");
-  int polltime_in_seconds = DEFAULT_POLLTIME_IN_SECONDS;
- 
-  // fileOptions is for parsing config files
-  boost::program_options::options_description fileOptions{"File"};
-  //sigh... with boost comes compilcated c++ magic
-  fileOptions.add_options() 
-    ("polltime", 
-     boost::program_options::value<int>()->default_value(DEFAULT_POLLTIME_IN_SECONDS), 
-     "polling interval");
-  boost::program_options::variables_map configOptions;  
-  try{
-    configOptions = loadConfig(configFile.getValue(),fileOptions);
-    // Check for information in configOptions
-    if(configOptions.count("polltime")) {
-      polltime_in_seconds = configOptions["polltime"].as<int>();
-    }  
-    syslog(LOG_INFO,
-	   "Setting poll time to %d seconds (%s)\n",
-	   polltime_in_seconds, 
-	   configOptions.count("polltime") ? "CONFIG FILE" : "DEFAULT");
-        
-  }catch(const boost::program_options::error &ex){
-    syslog(LOG_INFO, "Caught exception in function loadConfig(): %s \n", ex.what());    
-  }
+  // Now that syslog is available, we can continue to look at the config file and command line and determine if we should change the parameters from their default values.
+  setParamValue(&polltime_in_seconds, "polltime", configFileVM, commandLineVM, true);
+
+
+//  // Read from configuration file and set up parameters
+//  syslog(LOG_INFO,"Reading from config file now\n");
+//  int polltime_in_seconds = DEFAULT_POLLTIME_IN_SECONDS;
+// 
+//  // fileOptions is for parsing config files
+//  boost::program_options::options_description fileOptions{"File"};
+//  //sigh... with boost comes compilcated c++ magic
+//  fileOptions.add_options() 
+//    ("polltime", 
+//     boost::program_options::value<int>()->default_value(DEFAULT_POLLTIME_IN_SECONDS), 
+//     "polling interval");
+//  boost::program_options::variables_map configOptions;  
+//  try{
+//    configOptions = loadConfig(configFile.getValue(),fileOptions);
+//    // Check for information in configOptions
+//    if(configOptions.count("polltime")) {
+//      polltime_in_seconds = configOptions["polltime"].as<int>();
+//    }  
+//    syslog(LOG_INFO,
+//	   "Setting poll time to %d seconds (%s)\n",
+//	   polltime_in_seconds, 
+//	   configOptions.count("polltime") ? "CONFIG FILE" : "DEFAULT");
+//        
+//  }catch(const boost::program_options::error &ex){
+//    syslog(LOG_INFO, "Caught exception in function loadConfig(): %s \n", ex.what());    
+//  }
 
 
   // ============================================================================

--- a/src/standalone/ps_monitor.cxx
+++ b/src/standalone/ps_monitor.cxx
@@ -27,11 +27,9 @@
 #include <boost/program_options.hpp>  //for configfile parsing
 #include <fstream>
 
-//#include <tclap/CmdLine.h> //TCLAP parser
-
 #include <syslog.h>  ///for syslog
 
-#include <standalone/parseOptions.hh> // setOptions // setParamValues
+#include <standalone/parseOptions.hh> // setOptions // setParamValues // loadConfig
 
 #define SEC_IN_US  1000000
 #define NS_IN_US 1000
@@ -54,30 +52,6 @@ void static signal_handler(int const signum) {
 }
 
 // ====================================================================================================
-// Read from config files and set up all parameters
-// For further information see https://theboostcpplibraries.com/boost.program_options
-
-// boost::program_options::variables_map loadConfig(std::string const & configFileName,
-// 						 boost::program_options::options_description const & fileOptions) {
-//   // This is a container for the information that fileOptions will get from the config file
-//   boost::program_options::variables_map vm;  
-// 
-//   // Check if config file exists
-//   std::ifstream ifs{configFileName};
-//   syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
-// 
-//   if(ifs) {
-//     // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
-//     boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
-//   }
-// 
-//   return vm;
-// }
-
-
-
-
-// ====================================================================================================
 long us_difftime(struct timespec cur, struct timespec end){ 
   return ( (end.tv_sec  - cur.tv_sec )*SEC_IN_US + 
 	   (end.tv_nsec - cur.tv_nsec)/NS_IN_US);
@@ -87,26 +61,7 @@ long us_difftime(struct timespec cur, struct timespec end){
 
 int main(int argc, char ** argv) {
 
-//  TCLAP::CmdLine cmd("ApolloSM PS Monitor");
-//  TCLAP::ValueArg<std::string> configFile("c",                 //one char flag
-//					  "config_file",       // full flag name
-//					  "config file",       //description
-//					  false,               //required argument
-//					  DEFAULT_CONFIG_FILE, //Default value
-//					  "string",            //type
-//					  cmd);
-//  TCLAP::ValueArg<std::string>    runPath    ("r","run_path","run path",false,DEFAULT_RUN_DIR ,"string",cmd);
-//  TCLAP::ValueArg<std::string>    pidFileName("p","pid_file","pid file",false,DEFAULT_PID_FILE,"string",cmd);
-//
-//  try {
-//    cmd.parse(argc, argv);
-//  }catch (TCLAP::ArgException &e) {
-//    fprintf(stderr, "Failed to Parse Command Line\n");
-//    return -1;
-//  }
-
-  // parameters to get from command line or config file (config file itself) will not be in the config file, obviously)
-
+  // parameters to get from command line or config file (config file itself will not be in the config file, obviously)
   std::string configFile  = DEFAULT_CONFIG_FILE;
   std::string runPath     = DEFAULT_RUN_DIR;
   std::string pidFileName = DEFAULT_PID_FILE;
@@ -151,7 +106,6 @@ int main(int argc, char ** argv) {
     return -1;
   }
  
-
   // Look at the config file and command line and determine if we should change the parameters from their default values
   // Only run path and pid file are needed for the next bit of code. The other parameters can and should wait until syslog is available.
   setParamValue(&runPath    , "run_path", configFileVM, commandLineVM, false);
@@ -209,35 +163,6 @@ int main(int argc, char ** argv) {
   // ============================================================================
   // Now that syslog is available, we can continue to look at the config file and command line and determine if we should change the parameters from their default values.
   setParamValue(&polltime_in_seconds, "polltime", configFileVM, commandLineVM, true);
-
-
-//  // Read from configuration file and set up parameters
-//  syslog(LOG_INFO,"Reading from config file now\n");
-//  int polltime_in_seconds = DEFAULT_POLLTIME_IN_SECONDS;
-// 
-//  // fileOptions is for parsing config files
-//  boost::program_options::options_description fileOptions{"File"};
-//  //sigh... with boost comes compilcated c++ magic
-//  fileOptions.add_options() 
-//    ("polltime", 
-//     boost::program_options::value<int>()->default_value(DEFAULT_POLLTIME_IN_SECONDS), 
-//     "polling interval");
-//  boost::program_options::variables_map configOptions;  
-//  try{
-//    configOptions = loadConfig(configFile.getValue(),fileOptions);
-//    // Check for information in configOptions
-//    if(configOptions.count("polltime")) {
-//      polltime_in_seconds = configOptions["polltime"].as<int>();
-//    }  
-//    syslog(LOG_INFO,
-//	   "Setting poll time to %d seconds (%s)\n",
-//	   polltime_in_seconds, 
-//	   configOptions.count("polltime") ? "CONFIG FILE" : "DEFAULT");
-//        
-//  }catch(const boost::program_options::error &ex){
-//    syslog(LOG_INFO, "Caught exception in function loadConfig(): %s \n", ex.what());    
-//  }
-
 
   // ============================================================================
   // Daemon code setup

--- a/src/standalone/xvc_server.cxx
+++ b/src/standalone/xvc_server.cxx
@@ -62,22 +62,22 @@ void static signal_handler(int const signum) {
 
 // ==================================================
 
-boost::program_options::variables_map loadConfig(std::string const & configFileName,
-						 boost::program_options::options_description const & fileOptions) {
-  // This is a container for the information that fileOptions will get from the config file
-  boost::program_options::variables_map vm;  
-
-  // Check if config file exists
-  std::ifstream ifs{configFileName};
-  syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
-
-  if(ifs) {
-    // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
-    boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
-  }
-
-  return vm;
-}
+// boost::program_options::variables_map loadConfig(std::string const & configFileName,
+// 						 boost::program_options::options_description const & fileOptions) {
+//   // This is a container for the information that fileOptions will get from the config file
+//   boost::program_options::variables_map vm;  
+// 
+//   // Check if config file exists
+//   std::ifstream ifs{configFileName};
+//   syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
+// 
+//   if(ifs) {
+//     // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
+//     boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
+//   }
+// 
+//   return vm;
+// }
 
 // ==================================================
 

--- a/src/standalone/xvc_server.cxx
+++ b/src/standalone/xvc_server.cxx
@@ -36,12 +36,9 @@
 
 #include <fstream>
 
-//TCLAP parser
-//#include <tclap/CmdLine.h>
-
 #include <ApolloSM/uioLabelFinder.hh>
 
-#include <standalone/parseOptions.hh> // setOptions // setParamValues
+#include <standalone/parseOptions.hh> // setOptions // setParamValues // loadConfig
 
 //extern int errno;
 
@@ -59,25 +56,6 @@ void static signal_handler(int const signum) {
     loop = false;
   }
 }
-
-// ==================================================
-
-// boost::program_options::variables_map loadConfig(std::string const & configFileName,
-// 						 boost::program_options::options_description const & fileOptions) {
-//   // This is a container for the information that fileOptions will get from the config file
-//   boost::program_options::variables_map vm;  
-// 
-//   // Check if config file exists
-//   std::ifstream ifs{configFileName};
-//   syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
-// 
-//   if(ifs) {
-//     // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
-//     boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
-//   }
-// 
-//   return vm;
-// }
 
 // ==================================================
 
@@ -247,43 +225,8 @@ int main(int argc, char **argv) {
  
   int port;
   std::string xvcName;
-  
-//  try {
-//    TCLAP::CmdLine cmd("Apollo XVC.",
-//		       ' ',
-//		       "XVC");
-//   
-//    // XVC name base
-//    TCLAP::ValueArg<std::string> xvcPreFix("v",              //one char flag
-//					       "xvc",      // full flag name
-//					       "xvc prefix",//description
-//					       true,            //required
-//					       std::string(""),  //Default is empty
-//					       "string",         // type
-//					       cmd);
-//
-//    // port number
-//    TCLAP::ValueArg<int> xvcPort("p",              //one char flag
-//				 "port",      // full flag name
-//				 "xvc port number",//description
-//				 true,            //required
-//				 -1,  //Default is empty
-//				 "int",         // type
-//				 cmd);
-//
-//  
-//    //Parse the command line arguments
-//    cmd.parse(argc,argv);
-//
-//    port = xvcPort.getValue();
-//    xvcName=xvcPreFix.getValue();
-//    uioLabel = xvcPreFix.getValue();
-//  }catch (TCLAP::ArgException &e) {  
-//    syslog(LOG_ERR, "Error %s for arg %s\n",
-//	   e.error().c_str(), e.argId().c_str());
-//    return 0;
-//  }
 
+  // parameters to get from command line or config file (config file itself will not be in the config file, obviously)
   std::string configFile  = DEFAULT_CONFIG_FILE;
   std::string runPath     = DEFAULT_RUN_DIR;
   std::string pidFileName = DEFAULT_PID_FILE;

--- a/src/standalone/xvc_server.cxx
+++ b/src/standalone/xvc_server.cxx
@@ -34,16 +34,22 @@
 #include <vector>
 #include <string>
 
+#include <fstream>
+
 //TCLAP parser
-#include <tclap/CmdLine.h>
+//#include <tclap/CmdLine.h>
 
 #include <ApolloSM/uioLabelFinder.hh>
 
+#include <standalone/parseOptions.hh> // setOptions // setParamValues
+
 //extern int errno;
 
+#define DEFAULT_CONFIG_FILE "/etc/xvc_server"
 #define DEFAULT_RUN_DIR     "/opt/address_tables/"
 #define DEFAULT_PID_FILE    "/var/run/"
-
+#define DEFAULT_XVCPREFIX   ""
+#define DEFAULT_XVCPORT     -1
 
 // ====================================================================================================
 // signal handling
@@ -53,6 +59,27 @@ void static signal_handler(int const signum) {
     loop = false;
   }
 }
+
+// ==================================================
+
+boost::program_options::variables_map loadConfig(std::string const & configFileName,
+						 boost::program_options::options_description const & fileOptions) {
+  // This is a container for the information that fileOptions will get from the config file
+  boost::program_options::variables_map vm;  
+
+  // Check if config file exists
+  std::ifstream ifs{configFileName};
+  syslog(LOG_INFO, "Config file \"%s\" %s\n",configFileName.c_str(), (!ifs.fail()) ? "exists" : "does not exist");
+
+  if(ifs) {
+    // If config file exists, parse ifs into fileOptions and store information from fileOptions into vm
+    boost::program_options::store(parse_config_file(ifs, fileOptions), vm);
+  }
+
+  return vm;
+}
+
+// ==================================================
 
 #define MAP_SIZE      0x10000
 
@@ -221,47 +248,105 @@ int main(int argc, char **argv) {
   int port;
   std::string xvcName;
   
+//  try {
+//    TCLAP::CmdLine cmd("Apollo XVC.",
+//		       ' ',
+//		       "XVC");
+//   
+//    // XVC name base
+//    TCLAP::ValueArg<std::string> xvcPreFix("v",              //one char flag
+//					       "xvc",      // full flag name
+//					       "xvc prefix",//description
+//					       true,            //required
+//					       std::string(""),  //Default is empty
+//					       "string",         // type
+//					       cmd);
+//
+//    // port number
+//    TCLAP::ValueArg<int> xvcPort("p",              //one char flag
+//				 "port",      // full flag name
+//				 "xvc port number",//description
+//				 true,            //required
+//				 -1,  //Default is empty
+//				 "int",         // type
+//				 cmd);
+//
+//  
+//    //Parse the command line arguments
+//    cmd.parse(argc,argv);
+//
+//    port = xvcPort.getValue();
+//    xvcName=xvcPreFix.getValue();
+//    uioLabel = xvcPreFix.getValue();
+//  }catch (TCLAP::ArgException &e) {  
+//    syslog(LOG_ERR, "Error %s for arg %s\n",
+//	   e.error().c_str(), e.argId().c_str());
+//    return 0;
+//  }
+
+  std::string configFile  = DEFAULT_CONFIG_FILE;
+  std::string runPath     = DEFAULT_RUN_DIR;
+  std::string pidFileName = DEFAULT_PID_FILE;
+  std::string xvcPreFix   = DEFAULT_XVCPREFIX;
+  int xvcPort             = DEFAULT_XVCPORT;
+
+  // parse command line and config file to set parameters
+  boost::program_options::options_description fileOptions{"File"}; // for parsing config file
+  boost::program_options::options_description commandLineOptions{"Options"}; // for parsing command line
+  commandLineOptions.add_options()
+    ("config_file",
+     boost::program_options::value<std::string>(),
+     "config_file"); // This is the only option not also in the file option (obviously)
+  setOption(&fileOptions, &commandLineOptions, "run_path", "run path"         , runPath);
+  setOption(&fileOptions, &commandLineOptions, "pid_file", "pid file"         , pidFileName);
+  setOption(&fileOptions, &commandLineOptions, "xvc"     , "xvc prefix"       , xvcPreFix);
+  setOption(&fileOptions, &commandLineOptions, "port"    , "xvc port number"  , xvcPort);
+  boost::program_options::variables_map configFileVM; // for parsing config file
+  boost::program_options::variables_map commandLineVM; // for parsing command line
+
+  // The command line must be parsed before the config file so that we know if there is a command line specified config file
+  fprintf(stdout, "Parsing command line now\n");
   try {
-    TCLAP::CmdLine cmd("Apollo XVC.",
-		       ' ',
-		       "XVC");
-   
-    // XVC name base
-    TCLAP::ValueArg<std::string> xvcPreFix("v",              //one char flag
-					       "xvc",      // full flag name
-					       "xvc prefix",//description
-					       true,            //required
-					       std::string(""),  //Default is empty
-					       "string",         // type
-					       cmd);
-
-    // port number
-    TCLAP::ValueArg<int> xvcPort("p",              //one char flag
-				 "port",      // full flag name
-				 "xvc port number",//description
-				 true,            //required
-				 -1,  //Default is empty
-				 "int",         // type
-				 cmd);
-
-  
-    //Parse the command line arguments
-    cmd.parse(argc,argv);
-
-    port = xvcPort.getValue();
-    xvcName=xvcPreFix.getValue();
-    uioLabel = xvcPreFix.getValue();
-  }catch (TCLAP::ArgException &e) {  
-    syslog(LOG_ERR, "Error %s for arg %s\n",
-	   e.error().c_str(), e.argId().c_str());
-    return 0;
+    // parse command line
+    boost::program_options::store(boost::program_options::parse_command_line(argc, argv, commandLineOptions), commandLineVM);
+  } catch(const boost::program_options::error &ex) {
+    fprintf(stderr, "Caught exception while parsing command line: %s. Try (--). ex: --polltime \nTerminating xvc_server\n", ex.what());       
+    return -1;
   }
 
+  // Check for non default config file
+  if(commandLineVM.count("config_file")) {
+    configFile = commandLineVM["config_file"].as<std::string>();
+  }  
+  fprintf(stdout, "config file path: %s\n", configFile.c_str());
+
+  // Now the config file may be loaded
+  fprintf(stdout, "Reading from config file now\n");
+  try {
+    // parse config file
+    configFileVM = loadConfig(configFile, fileOptions);
+  } catch(const boost::program_options::error &ex) {
+    fprintf(stdout, "Caught exception in function loadConfig(): %s \nTerminating xvc_server\n", ex.what());        
+    return -1;
+  }
+ 
+
+  // Look at the config file and command line and determine if we should change the parameters from their default values
+  setParamValue(&runPath    , "run_path", configFileVM, commandLineVM, false);
+  setParamValue(&pidFileName, "pid_file", configFileVM, commandLineVM, false);
+  setParamValue(&xvcPort    , "port"    , configFileVM, commandLineVM, false);
+  setParamValue(&xvcPreFix  , "xvc"     , configFileVM, commandLineVM, false);
+
+  port     = xvcPort;
+  xvcName  = xvcPreFix;
+  uioLabel = xvcPreFix;
 
   //now that we know the port, setup the log
   char daemonName[] = "xvc_server.XXXXXY"; //The 'Y' is so strlen is properly padded
   snprintf(daemonName,strlen(daemonName),"xvc_server.%u",port);
-  
+  pidFileName+=daemonName;
+  pidFileName+=".pid";
+ 
   // ============================================================================
   // Deamon book-keeping
   pid_t pid, sid;
@@ -272,22 +357,23 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }else if(pid > 0){
     //We are the parent and created a child with pid pid
-    std::string pidFileName = DEFAULT_PID_FILE;
-    pidFileName+=daemonName;
-    pidFileName+=".pid";
+//    std::string pidFileName = DEFAULT_PID_FILE;
+//    pidFileName+=daemonName;
+//    pidFileName+=".pid";
     FILE * pidFile = fopen(pidFileName.c_str(),"w");
     fprintf(pidFile,"%d\n",pid);
     fclose(pidFile);
     exit(EXIT_SUCCESS);
   }else{
     // I'm the child!
+    openlog(daemonName,LOG_PERROR|LOG_PID|LOG_ODELAY,LOG_DAEMON);
   }
-
+  
   
   //Change the file mode mask to allow read/write
   umask(0);
   
-  openlog(daemonName,LOG_PERROR|LOG_PID|LOG_ODELAY,LOG_DAEMON);
+  //  openlog(daemonName,LOG_PERROR|LOG_PID|LOG_ODELAY,LOG_DAEMON);
   syslog(LOG_INFO,"starting %s", daemonName);
   
 
@@ -311,7 +397,7 @@ int main(int argc, char **argv) {
   close(STDOUT_FILENO);
   close(STDERR_FILENO);
 
-
+  // ============================================================================
 
 
   //Find UIO number


### PR DESCRIPTION
SM_boot in feature-Factorize had some code factorized out into daemon.hh and daemon.cc. SM_boot is already using command line options with boost and the code in daemon.hh and daemon.cc was written with that in mind. The other daemons are not using command line options so I cannot factorize (working from feature-Factorize) their code out until I merge changes from feature-AllDaemonCommandLineOptions into feature-Factorize.